### PR TITLE
Recalculate --fingerprint from image-name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,10 +298,9 @@ jobs:
   sdlc-control-gate:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    needs: [setup, build-image, rubocop-lint, pull-request, unit-tests, snyk-container-scan, snyk-code-scan, sonarcloud-scan]
+    needs: [build-image, rubocop-lint, pull-request, unit-tests, snyk-container-scan, snyk-code-scan, sonarcloud-scan]
     env:
-      IMAGE_NAME:        ${{ needs.setup.outputs.image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
+      IMAGE_NAME: ${{ needs.build-image.outputs.tagged_image_name }}
     steps:
       - name: Setup Kosli CLI
         uses: kosli-dev/setup-cli-action@v2
@@ -315,15 +314,15 @@ jobs:
       - name: Kosli SDLC gate to short-circuit the workflow
         run:
           kosli assert artifact "${IMAGE_NAME}"
+            --artifact-type=oci
             --environment=${KOSLI_AWS_BETA}
 
 
   approve-deployment-to-beta:
     runs-on: ubuntu-latest
-    needs: [setup, build-image, sdlc-control-gate]
+    needs: [build-image, sdlc-control-gate]
     env:
-      IMAGE_NAME:        ${{ needs.setup.outputs.image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
+      IMAGE_NAME: ${{ needs.build-image.outputs.tagged_image_name }}
     environment:
       name: staging
       url:  https://beta.cyber-dojo.org
@@ -340,6 +339,7 @@ jobs:
       - name: Report approval of deployment to Kosli
         run:
           kosli report approval "${IMAGE_NAME}"
+            --artifact-type=oci
             --approver="${{ github.actor }}"
             --environment=${KOSLI_AWS_BETA}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ env:
   KOSLI_ORG:           ${{ vars.KOSLI_ORG }}                   # cyber-dojo
   KOSLI_FLOW:          ${{ vars.KOSLI_FLOW }}                  # dashboard-ci
   KOSLI_TRAIL:         ${{ github.sha }}
-  KOSLI_ARTIFACT_TYPE: oci
 
   AWS_ECR_ID:          ${{ vars.AWS_ECR_ID }}
   AWS_REGION:          ${{ vars.AWS_REGION }}
@@ -205,9 +204,9 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [setup, build-image]
+    needs: [build-image]
     env:
-      IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
+      IMAGE_NAME: ${{ needs.build-image.outputs.tagged_image_name }}
     steps:
       - name: Download docker image
         uses: cyber-dojo/download-artifact@main
@@ -237,6 +236,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
         run:
           kosli attest junit ${IMAGE_NAME}
+            --artifact-type=oci
             --name=dashboard.unit-test 
             --results-dir=./reports/server/junit
 
@@ -245,6 +245,7 @@ jobs:
         run: |
           KOSLI_COMPLIANT=$([ "${{ steps.coverage.outcome }}" == 'success' ] && echo true || echo false)          
           kosli attest generic ${IMAGE_NAME} \
+            --artifact-type=oci
             --description="unit-test branch-coverage and metrics" \
             --name=dashboard.unit-test-coverage \
             --user-data=./reports/server/coverage_metrics.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,15 +5,15 @@ on:
   push:
 
 env:
-  KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
-  KOSLI_AWS_BETA:  ${{ vars.KOSLI_AWS_BETA }}              # aws-beta
-  KOSLI_ACTIVE:    ${{ github.ref == 'refs/heads/main' }}  # true/false
-  KOSLI_DEBUG:     ${{ vars.KOSLI_DEBUG }}                 # true/false
-  KOSLI_DRY_RUN:   ${{ vars.KOSLI_DRY_RUN }}               # true/false
-  KOSLI_HOST:      ${{ vars.KOSLI_HOST }}                  # https://app.kosli.com
-  KOSLI_ORG:       ${{ vars.KOSLI_ORG }}                   # cyber-dojo
-  KOSLI_FLOW:      ${{ vars.KOSLI_FLOW }}                  # dashboard-ci
-  KOSLI_TRAIL:     ${{ github.sha }}
+  KOSLI_API_TOKEN:     ${{ secrets.KOSLI_API_TOKEN }}
+  KOSLI_AWS_BETA:      ${{ vars.KOSLI_AWS_BETA }}              # aws-beta
+  KOSLI_DEBUG:         ${{ vars.KOSLI_DEBUG }}                 # true/false
+  KOSLI_DRY_RUN:       ${{ vars.KOSLI_DRY_RUN }}               # true/false
+  KOSLI_HOST:          ${{ vars.KOSLI_HOST }}                  # https://app.kosli.com
+  KOSLI_ORG:           ${{ vars.KOSLI_ORG }}                   # cyber-dojo
+  KOSLI_FLOW:          ${{ vars.KOSLI_FLOW }}                  # dashboard-ci
+  KOSLI_TRAIL:         ${{ github.sha }}
+  KOSLI_ARTIFACT_TYPE: oci
 
   AWS_ECR_ID:          ${{ vars.AWS_ECR_ID }}
   AWS_REGION:          ${{ vars.AWS_REGION }}
@@ -207,8 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, build-image]
     env:
-      IMAGE_NAME:        ${{ needs.setup.outputs.image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
+      IMAGE_NAME: ${{ needs.setup.outputs.image_name }}
     steps:
       - name: Download docker image
         uses: cyber-dojo/download-artifact@main
@@ -237,7 +236,7 @@ jobs:
       - name: Attest JUnit test evidence to Kosli
         if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
         run:
-          kosli attest junit
+          kosli attest junit ${IMAGE_NAME}
             --name=dashboard.unit-test 
             --results-dir=./reports/server/junit
 
@@ -245,7 +244,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
         run: |
           KOSLI_COMPLIANT=$([ "${{ steps.coverage.outcome }}" == 'success' ] && echo true || echo false)          
-          kosli attest generic \
+          kosli attest generic ${IMAGE_NAME} \
             --description="unit-test branch-coverage and metrics" \
             --name=dashboard.unit-test-coverage \
             --user-data=./reports/server/coverage_metrics.json


### PR DESCRIPTION
This is safer than reusing the fingerprint output of the build job. Eg suppose 'make test_server' is building a new image.