### PR TITLE
Revert to standard ubuntu-latest GitHub Actions runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-
 name: Main
 
 on:
@@ -22,7 +21,7 @@ env:
 jobs:
 
   setup:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       aws_account_id_beta:      ${{ steps.vars.outputs.aws_account_id_beta }}
       ecr_registry:             ${{ steps.vars.outputs.ecr_registry }}
@@ -30,7 +29,6 @@ jobs:
       gh_actions_iam_role_name: ${{ steps.vars.outputs.gh_actions_iam_role_name }}
       service_name:             ${{ steps.vars.outputs.service_name }}
       image_tag:                ${{ steps.vars.outputs.image_tag }}
-      image_name:               ${{ steps.vars.outputs.image_name }}
       kosli_trail:              ${{ steps.vars.outputs.kosli_trail }}
     steps:
       - name: Harden Runner
@@ -45,16 +43,15 @@ jobs:
         run: |
           ECR_REGISTRY="${AWS_ECR_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
           IMAGE_TAG="${GITHUB_SHA:0:7}"
-          IMAGE_NAME="${ECR_REGISTRY}/${SERVICE_NAME}:${IMAGE_TAG}"          
-          { 
-            echo "aws_account_id_beta=${AWS_ACCOUNT_ID_BETA}"             
-            echo "ecr_registry=${ECR_REGISTRY}"                 
-            echo "aws_region=${AWS_REGION}"                     
-            echo "gh_actions_iam_role_name=gh_actions_services" 
-            echo "service_name=${SERVICE_NAME}"                 
-            echo "image_tag=${IMAGE_TAG}"                       
-            echo "image_name=${IMAGE_NAME}"
-            echo "kosli_trail=${KOSLI_TRAIL}"                   
+          IMAGE_NAME="${ECR_REGISTRY}/${SERVICE_NAME}:${IMAGE_TAG}"
+          {
+            echo "aws_account_id_beta=${AWS_ACCOUNT_ID_BETA}"
+            echo "ecr_registry=${ECR_REGISTRY}"
+            echo "aws_region=${AWS_REGION}"
+            echo "gh_actions_iam_role_name=gh_actions_services"
+            echo "service_name=${SERVICE_NAME}"
+            echo "image_tag=${IMAGE_TAG}"
+            echo "kosli_trail=${KOSLI_TRAIL}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Begin Kosli Trail
@@ -67,7 +64,7 @@ jobs:
 
   pull-request:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [setup]
     permissions:
       id-token:      write
@@ -94,7 +91,7 @@ jobs:
 
 
   # workflow-lint:
-  #   runs-on: blacksmith-4vcpu-ubuntu-2404
+  #   runs-on: ubuntu-latest
   #   needs: [setup]
   #   permissions:
   #     contents: read
@@ -104,15 +101,13 @@ jobs:
   #       uses: step-security/harden-runner@v2
   #       with:
   #         egress-policy: audit
-
   #     - uses: actions/checkout@v6
-
   #     - name: Action Lint
   #       uses: devops-actions/actionlint@v0.1.9
 
 
   rubocop-lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [setup]
     steps:
       - name: Harden Runner
@@ -141,7 +136,7 @@ jobs:
 
 
   sonarcloud-scan:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [setup]
     steps:
       - name: Harden Runner
@@ -195,7 +190,7 @@ jobs:
   # https://github.com/cyber-dojo/snyk-container-test/blob/main/action.yml
   snyk-container-scan:
     needs: [build-image]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
@@ -210,7 +205,7 @@ jobs:
 
 
   unit-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [build-image]
     env:
       KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
@@ -246,7 +241,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run:
           kosli attest junit
-            --name=dashboard.unit-test 
+            --name=dashboard.unit-test
             --results-dir=./reports/server/junit
 
       - name: Attest coverage evidence to Kosli
@@ -262,7 +257,7 @@ jobs:
 
   sdlc-control-gate:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - build-image
       - rubocop-lint


### PR DESCRIPTION
Undoes the Blacksmith runner migration (commits ea0e3bb, 3f68648, c5ddce8):
- Replace blacksmith-4vcpu-ubuntu-2404 with ubuntu-latest across all jobs
- workflow-lint job remains commented out (kept as-is from user edits)