### PR TITLE
Remove defunct Google Analytics tracking code

### DIFF
--- a/source/server/app/views/layout.erb
+++ b/source/server/app/views/layout.erb
@@ -9,15 +9,6 @@
     <script>const cd = {};/*CyberDojo 'namespace'*/</script>
     <link  href="/dashboard/assets/app.css" rel="stylesheet" />
     <script src="/dashboard/assets/app.js"></script>
-    <script>
-      /*global cd,$*/
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-15608469-5', 'cyber-dojo.org');
-      ga('send', 'pageview');
-    </script>
   </head>
   <body>
     <%= yield %>


### PR DESCRIPTION
Universal Analytics (analytics.js) was shut down in July 2023. The inline GA script in layout.erb was making noisy requests and producing "Reporting Header: invalid JSON value received" console errors. Removing it entirely.