### PR TITLE
Remove HTTP calls for avatar names - hardcode the list instead

### DIFF
--- a/source/server/app/assets/javascripts/hover_tips.js
+++ b/source/server/app/assets/javascripts/hover_tips.js
@@ -3,13 +3,9 @@
 
   cd.setupAvatarNameHoverTip = ($avatar, prefix, avatarIndex, suffix) => {
     setTip($avatar, () => {
-      fetch('/images/avatars/names.json', { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
-        .then(r => r.json())
-        .then(avatarsNames => {
-          const avatarName = avatarsNames[avatarIndex];
-          const tip = `${prefix}${avatarName}${suffix}`;
-          showHoverTip($avatar, tip);
-        });
+      const avatarName = cd.lib.avatarName(avatarIndex);
+      const tip = `${prefix}${avatarName}${suffix}`;
+      showHoverTip($avatar, tip);
     });
   };
 

--- a/source/server/app/assets/javascripts/lib_avatar_name.js
+++ b/source/server/app/assets/javascripts/lib_avatar_name.js
@@ -1,21 +1,18 @@
 'use strict';
 (() => {
 
-  let avatarNamesCache = undefined;
+  const avatarNames = [
+    "alligator", "antelope", "bat", "bear", "bee", "beetle", "buffalo",
+    "butterfly", "cheetah", "crab", "deer", "dolphin", "eagle", "elephant",
+    "flamingo", "fox", "frog", "gopher", "gorilla", "heron", "hippo",
+    "hummingbird", "hyena", "jellyfish", "kangaroo", "kingfisher", "koala",
+    "leopard", "lion", "lizard", "lobster", "moose", "mouse", "ostrich",
+    "owl", "panda", "parrot", "peacock", "penguin", "porcupine", "puffin",
+    "rabbit", "raccoon", "ray", "rhino", "salmon", "seal", "shark", "skunk",
+    "snake", "spider", "squid", "squirrel", "starfish", "swan", "tiger",
+    "toucan", "tuna", "turtle", "vulture", "walrus", "whale", "wolf", "zebra"
+  ];
 
-  cd.lib.avatarName = (n) => {
-    if (avatarNamesCache === undefined) {
-      $.ajax({
-              type: 'GET',
-               url: '/images/avatars/names.json',
-          dataType: 'json',
-             async: false,
-           success: (avatarsNames) => {
-             avatarNamesCache = avatarsNames;
-           }
-      });
-    }
-    return avatarNamesCache[n];
-  };
+  cd.lib.avatarName = (n) => avatarNames[n];
 
 })();


### PR DESCRIPTION
Both lib_avatar_name.js ($.ajax, synchronous) and hover_tips.js (fetch) were fetching /images/avatars/names.json at runtime. The ../web repo solves this by hardcoding the fixed list of 64 avatar names directly in lib_avatar_name.js. Applied the same approach here, and updated hover_tips.js to call cd.lib.avatarName() directly.