### PR TITLE
Restore avatar column to left alignment

### DIFF
--- a/source/server/app/assets/stylesheets/dashboard.scss
+++ b/source/server/app/assets/stylesheets/dashboard.scss
@@ -33,7 +33,6 @@
       // display:table so position:sticky works for the full scroll range.
       width: max-content;
       height: 100%;
-      margin: auto;
       border-collapse: separate;
       border-spacing: 0;
     }


### PR DESCRIPTION
Removing display:inline-block in #376 meant margin:auto started centering the table horizontally. Dropping margin:auto lets the table sit at the left edge as it did before.