### PR TITLE
Fix diff_summary route - remove erroneous /dashboard prefix

### DIFF
--- a/source/server/app/app.rb
+++ b/source/server/app/app.rb
@@ -38,7 +38,7 @@ class App < AppBase
     end
   end
 
-  get '/dashboard/diff_summary', provides: [:json] do
+  get '/diff_summary', provides: [:json] do
     respond_to do |wants|
       wants.json do
         id = params[:id]


### PR DESCRIPTION
The Sinatra app's routes must not carry the /dashboard prefix since the reverse proxy strips it before forwarding. /dashboard/diff_summary in app.rb would only be reachable at /dashboard/dashboard/diff_summary on the deployed site, causing 404s. The JS correctly calls /dashboard/diff_summary; the app route must be /diff_summary to match.