### PR TITLE
Stop publishing dashboard host ports so concurrent runs don't collide

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -106,6 +106,7 @@ demo()
 
   docker compose \
     --file "$(repo_root)/docker-compose.yml" \
+    --file "$(repo_root)/docker-compose.demo.yml" \
     run \
       --detach \
       --service-ports \

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -43,7 +43,7 @@ remove_all_but_latest()
   for image_name in $(echo "${docker_image_ls}" | grep "${name}:")
   do
     if [ "${image_name}" != "${name}:latest" ]; then
-      docker image rm --force "${image_name}"
+      docker image rm --force "${image_name}" || echo "  skipped ${image_name} (in use)"
     fi
   done
   docker system prune --force

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,20 @@
+# Demo-only overlay, layered on top of docker-compose.yml.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.demo.yml run --service-ports nginx
+#
+# The base docker-compose.yml deliberately publishes no host ports (see its
+# comment) so concurrent test runs - here and in sibling repos - don't collide.
+# The demo needs two host ports:
+#   - nginx, so a browser can open the dashboard through the real routing
+#     (bin/demo.sh opens http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/...).
+#   - dashboard itself, because bin/demo.sh's curl_smoke_test curls it directly
+#     on CYBER_DOJO_DASHBOARD_PORT, bypassing nginx.
+# See bin/demo.sh.
+
+services:
+
+  nginx:
+    ports: [ "${CYBER_DOJO_NGINX_HOST_PORT:-80}:80" ]
+
+  dashboard:
+    ports: [ "${CYBER_DOJO_DASHBOARD_PORT}:${CYBER_DOJO_DASHBOARD_PORT}" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 
+# No service publishes a host port. The tests run inside the containers (via
+# docker exec - see bin/run_tests.sh) and inter-service traffic flows over the
+# project's private network by compose service name, so nothing needs a host
+# port. Not publishing means several test runs - in this repo or in sibling
+# repos - can run at once without fighting over the same host ports (eg 80).
+# The demo overlay (docker-compose.demo.yml) publishes the few ports the demo
+# needs.
+
 networks:
   cyber-dojo:
     driver: bridge
@@ -38,7 +46,6 @@ services:
       - differ
       - saver
     env_file: [ .env ]
-    ports: [ "${CYBER_DOJO_DASHBOARD_PORT}:${CYBER_DOJO_DASHBOARD_PORT}" ]
     read_only: true
     restart: no
     volumes:
@@ -59,7 +66,6 @@ services:
       - web
     user: root
     init: true
-    ports: [ "${CYBER_DOJO_NGINX_HOST_PORT:-80}:80" ]
     restart: "no"
 
   web:


### PR DESCRIPTION
    The base docker-compose.yml published two host ports: dashboard
    (CYBER_DOJO_DASHBOARD_PORT) and nginx (:80). Neither is needed by the tests -
    they run inside the containers via docker exec and reach every service by its
    compose service name over the project's private network. But binding the host
    made a test run fight any sibling repo's test or demo for the same ports (:80
    especially), so "port is already allocated" could abort the run.

    Publish nothing from the base compose; let the private network carry all
    inter-service traffic. The demo still needs both host ports, so a new
    docker-compose.demo.yml overlay publishes them: nginx (so a browser can open
    the dashboard through the real routing) and dashboard (bin/demo.sh's
    curl_smoke_test curls it directly, bypassing nginx). bin/demo.sh now layers
    the overlay onto the base file. Mirrors the same change already made in creator.

    Also make bin/lib.sh remove_all_but_latest best-effort: "docker image rm
    --force" still fails when an image is held by a running container (from another
    compose project), which aborted the build under set -Eeu. Skip in-use images
    instead so the build always proceeds.