### PR TITLE
Help reviewers work through a cluster on the dashboard

### DIFF
--- a/source/server/app/app.rb
+++ b/source/server/app/app.rb
@@ -80,7 +80,7 @@ class App < AppBase
       @tabs = groups.map do |group_id, manifest|
         { 'id' => group_id, 'display_name' => manifest['display_name'] }
       end
-      @group_id = group ? group['id'] : @tabs.first['id']
+      @group_id = active_child_id(group)
     else
       @tabs = []
       @group_id = group ? group['id'] : @id
@@ -91,6 +91,18 @@ class App < AppBase
     # behaviour - and let the per-child fetches surface any error, as before.
     @tabs = []
     @group_id = @id
+  end
+
+  # Picks which child group of a cluster is the initially-active tab. A
+  # ?group_id= query param naming a real child wins (deep-linking straight to
+  # one LTF's tab); otherwise the child from the resolved path id, else the
+  # first tab. An unknown group_id is ignored so we never activate an absent
+  # tab.
+  def active_child_id(group)
+    wanted = params[:group_id]
+    return wanted if @tabs.any? { |tab| tab['id'] == wanted }
+
+    group ? group['id'] : @tabs.first['id']
   end
 
   def altered(indexes, gapped)

--- a/source/server/app/assets/stylesheets/fixed-column.scss
+++ b/source/server/app/assets/stylesheets/fixed-column.scss
@@ -7,6 +7,7 @@
 .pie-chart-wrapper
 {
   padding: 0 2px;
+  margin-left: 6px; // space between the avatar-image and the pie-chart
 }
 
 .sort-header

--- a/source/server/app/assets/stylesheets/traffic-light-count.scss
+++ b/source/server/app/assets/stylesheets/traffic-light-count.scss
@@ -4,7 +4,7 @@
   @include non-code-font();
   cursor: default;
   margin: 0px;
-  padding: { left: 8px; right: 5px; }
+  padding: { left: 8px; right: 12px; } // right: space before the lights
   font-size: 22px;
   position: relative;
   top: -2px;

--- a/source/server/app/views/show.erb
+++ b/source/server/app/views/show.erb
@@ -14,9 +14,31 @@ $(() => {
 
   cd.refresh();
   const seconds = (n) => n * 1000; // millisecs
+
+  // For a cluster (more than one tab) the auto-refresh heartbeat slowly
+  // rotates through the child groups: it dwells on each group for DWELL_BEATS
+  // heartbeats (refreshing its data in place) then advances to the next tab,
+  // wrapping around. A standalone group (no tabs) just refreshes in place.
+  // Rotation is driven entirely by the existing auto-refresh checkbox; it is
+  // purely time-based apart from this one dwell counter.
+  const DWELL_BEATS = 3; // ~30s per group (heartbeat fires every 10s)
+  let dwell = 0;
+  cd.resetDwell = () => { dwell = 0; };
+
+  const isCluster = () => cd.tabs().length > 1;
+  const nextGroupId = () => {
+    const ids = cd.tabs().map((tab) => tab['id']);
+    return ids[(ids.indexOf(cd.groupId()) + 1) % ids.length];
+  };
+
   const heartbeat = () => {
     if (cd.autoRefresh.isChecked()) {
-      cd.refresh();
+      if (isCluster() && ++dwell >= DWELL_BEATS) {
+        dwell = 0;
+        cd.activateGroup(nextGroupId()); // advances the tab and refreshes
+      } else {
+        cd.refresh();
+      }
     }
     setTimeout(heartbeat, seconds(10));
   };

--- a/source/server/app/views/tabs.erb
+++ b/source/server/app/views/tabs.erb
@@ -13,18 +13,25 @@
 'use strict';
 $(() => {
 
-  // Each tab is one child group of the cluster. Clicking a tab makes its
+  // Each tab is one child group of the cluster. Activating a tab makes its
   // group the active child: all per-child fetches (heartbeat, group_manifest,
   // progress) then key off it, and the traffic-lights grid + manifest reload
-  // in place. cd.id() (the cluster id in the URL) is unchanged.
+  // in place. cd.id() (the cluster id in the URL) is unchanged. Both a manual
+  // click and the auto-refresh rotation (see show.erb) go through here.
+  cd.activateGroup = (groupId) => {
+    const $tabs = $('#cluster-tabs .cluster-tab');
+    $tabs.removeClass('cluster-tab-active');
+    $tabs.filter(`[data-group-id="${groupId}"]`).addClass('cluster-tab-active');
+    cd.setGroupId(groupId);
+    cd.loadManifest();
+    cd.refresh();
+  };
+
   $('#cluster-tabs .cluster-tab').click(function() {
     const $tab = $(this);
     if ($tab.hasClass('cluster-tab-active')) { return; }
-    $('#cluster-tabs .cluster-tab').removeClass('cluster-tab-active');
-    $tab.addClass('cluster-tab-active');
-    cd.setGroupId($tab.data('group-id').toString());
-    cd.loadManifest();
-    cd.refresh();
+    cd.activateGroup($tab.data('group-id').toString());
+    cd.resetDwell(); // a manual pick gets a full dwell before auto-advancing
   });
 
 });

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -24,21 +24,21 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=',  22 ],
+    [ 'test.count',    stats['test_count'],    '>=',  24 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '<=',  0 ],
     [ 'test.errors',   stats['error_count'  ], '<=',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '<=',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 291 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 299 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '<=', 4   ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '<=', 0   ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 427 ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 431 ],
     [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=', 83  ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 60  ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 62  ],
     [ 'code.branches.missed',  code_cov['branches']['missed'], '<=', 26  ],
   ]
 end

--- a/test/server/cluster_tabs_test.rb
+++ b/test/server/cluster_tabs_test.rb
@@ -41,11 +41,29 @@ class ClusterTabsTest < TestBase
     refute_includes html, 'id="cluster-tabs"', html
   end
 
+  test 'c1u5b4', %w(
+  | a group_id query param inside a cluster selects that child as the active
+  | tab, overriding the bare-cluster-id default of the first child
+  ) do
+    html = show_html(CLUSTER_ID, group_id: '4tSCxB')
+    assert_includes html, 'id="cluster-tabs"', html
+    assert_equal '4tSCxB', active_tab_id(html), html
+  end
+
+  test 'c1u5b5', %w(
+  | a group_id query param that names no child of the cluster is ignored:
+  | the active tab falls back to the first child (never an absent tab)
+  ) do
+    html = show_html(CLUSTER_ID, group_id: 'nosuch')
+    assert_includes html, 'id="cluster-tabs"', html
+    assert_equal '8qTubq', active_tab_id(html), html
+  end
+
   private
 
   # GETs /show/<id> as html, asserts a 200, and returns the response body.
-  def show_html(id)
-    get "/show/#{id}", {}, { 'HTTP_ACCEPT' => 'text/html' }
+  def show_html(id, params = {})
+    get "/show/#{id}", params, { 'HTTP_ACCEPT' => 'text/html' }
     assert status?(200), "status=#{status}"
     last_response.body
   end


### PR DESCRIPTION
  When reviewing a cluster session a reviewer has to watch every LTF child
  group, but the dashboard only ever showed one group at a time and gave no
  hands-off way to move between them. Three changes make a cluster easier to
  sit and watch:

  - Auto-refresh now slowly rotates through a cluster's groups. While the existing auto-refresh checkbox is on, the heartbeat dwells ~30s on each group (refreshing it in place) then advances to the next tab, wrapping around. A standalone group still just refreshes in place. Manually clicking a tab resets the dwell so a group you pick by hand gets a full ~30s before it moves on. The click and rotation paths now share one cd.activateGroup().

  - /show/<clusterId>?group_id=<childId> deep-links straight to one group's tab. An unknown group_id is ignored and falls back to the first child, so the URL can never activate an absent tab.

  - Widen the fixed column: more space between the avatar and pie-chart, and between the lights-count and the lights, so a row is easier to read. The spacing is scoped to the fixed column so the top-bar avatars are unaffected.