### PR TITLE
Skip dormant tabs when a cluster dashboard auto-refreshes

### DIFF
--- a/source/server/app/app.rb
+++ b/source/server/app/app.rb
@@ -58,7 +58,41 @@ class App < AppBase
     end
   end
 
+  get '/active_groups/:id', provides: [:json] do
+    respond_to do |wants|
+      wants.json do
+        json(active_groups)
+      end
+    end
+  end
+
   private
+
+  # For each child group of the cluster @id resolves up to, whether that group
+  # has any avatar with a non-creation event (a traffic-light) - ie whether it
+  # is worth rotating a cluster dashboard's auto-refresh onto. Keyed by child
+  # group id. Empty for a standalone group (no cluster - nothing to rotate).
+  def active_groups
+    chain = externals.saver.id_chain(params[:id])
+    cluster = chain.find { |entry| entry['type'] == 'cluster' }
+    return {} unless cluster
+
+    group_ids = externals.saver.cluster_manifest(cluster['id'])['groups'].keys
+    group_ids.to_h { |group_id| [group_id, group_active?(group_id)] }
+  rescue StandardError
+    # Best-effort, like resolve_group_and_tabs: on any saver hiccup report
+    # nothing active so the caller simply refreshes in place, never crashing.
+    {}
+  end
+
+  # True when any avatar in the group has a non-creation event. A freshly
+  # joined avatar has only its index-0 'created' event; a test run adds an
+  # event with index != 0. Matches gatherer's has_activity notion.
+  def group_active?(group_id)
+    externals.saver.group_joined(group_id).any? do |_avatar_index, o|
+      o['events'].any? { |event| event['index'] != 0 }
+    end
+  end
 
   helpers AvatarsProgressHelper
   helpers GathererHelper

--- a/source/server/app/views/show.erb
+++ b/source/server/app/views/show.erb
@@ -17,25 +17,52 @@ $(() => {
 
   // For a cluster (more than one tab) the auto-refresh heartbeat slowly
   // rotates through the child groups: it dwells on each group for DWELL_BEATS
-  // heartbeats (refreshing its data in place) then advances to the next tab,
-  // wrapping around. A standalone group (no tabs) just refreshes in place.
-  // Rotation is driven entirely by the existing auto-refresh checkbox; it is
-  // purely time-based apart from this one dwell counter.
+  // heartbeats (refreshing its data in place) then advances to the next tab.
+  // It only rotates onto a group that currently has activity (an avatar with a
+  // non-creation event), per /active_groups, skipping dormant tabs; if no other
+  // group is active it stays put. All tabs stay visible either way. A standalone
+  // group (no tabs) just refreshes in place. Rotation is driven entirely by the
+  // existing auto-refresh checkbox; it is time-based apart from this dwell counter.
   const DWELL_BEATS = 3; // ~30s per group (heartbeat fires every 10s)
   let dwell = 0;
   cd.resetDwell = () => { dwell = 0; };
 
   const isCluster = () => cd.tabs().length > 1;
-  const nextGroupId = () => {
+
+  // The next tab (in tab order, wrapping) whose group has activity in the
+  // active-map from /active_groups. Falls back to the current group when no
+  // other active group exists, so rotation never lands on a dormant tab.
+  const nextActiveGroupId = (active) => {
     const ids = cd.tabs().map((tab) => tab['id']);
-    return ids[(ids.indexOf(cd.groupId()) + 1) % ids.length];
+    const start = ids.indexOf(cd.groupId());
+    for (let step = 1; step <= ids.length; step++) {
+      const candidate = ids[(start + step) % ids.length];
+      if (active[candidate]) { return candidate; }
+    }
+    return cd.groupId();
+  };
+
+  // Advance the rotation onto the next active group; if that is the current
+  // group (nothing else active) just refresh in place.
+  const rotateToNextActiveGroup = () => {
+    fetch(`/dashboard/active_groups/${cd.id()}`, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } })
+      .then((response) => response.json())
+      .then((active) => {
+        const nextId = nextActiveGroupId(active);
+        if (nextId === cd.groupId()) {
+          cd.refresh();
+        } else {
+          cd.activateGroup(nextId); // advances the tab and refreshes
+        }
+      })
+      .catch(() => cd.refresh());
   };
 
   const heartbeat = () => {
     if (cd.autoRefresh.isChecked()) {
       if (isCluster() && ++dwell >= DWELL_BEATS) {
         dwell = 0;
-        cd.activateGroup(nextGroupId()); // advances the tab and refreshes
+        rotateToNextActiveGroup();
       } else {
         cd.refresh();
       }

--- a/test/server/active_groups_test.rb
+++ b/test/server/active_groups_test.rb
@@ -1,0 +1,126 @@
+require_relative 'test_base'
+require 'json'
+require 'net/http'
+
+class ActiveGroupsTest < TestBase
+
+  # Cluster eyxahp is baked into the saver test data (see cluster_tabs_test.rb);
+  # every one of its three child groups has avatars with traffic-lights.
+  BAKED_CLUSTER_ID = 'eyxahp'
+  BAKED_CHILD_IDS = %w[8qTubq 4tSCxB 5NjQeF].freeze
+  # A standalone group (in no cluster), also baked in.
+  STANDALONE_GROUP_ID = 'LyQpFr'
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'a6t1v1', %w(
+  | GET /active_groups reports, per child group of a cluster, whether it has
+  | any avatar with a non-creation event; a child that has only been joined
+  | (no test run) is reported false, a child with a run is reported true
+  ) do
+    cluster_id = create_cluster(%w[LTF-A LTF-B])
+    active_child, inactive_child = child_group_ids(cluster_id)
+    give_traffic_light(join_avatar(active_child))
+    join_avatar(inactive_child) # joined only - no run, so no traffic-light
+
+    active = get_active_groups(cluster_id)
+    assert_equal({ active_child => true, inactive_child => false }, active, active)
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'a6t1v2', %w(
+  | GET /active_groups for a cluster whose every child has traffic-lights
+  | reports every child true
+  ) do
+    active = get_active_groups(BAKED_CLUSTER_ID)
+    assert_equal BAKED_CHILD_IDS.to_h { |id| [id, true] }, active, active
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'a6t1v3', %w(
+  | GET /active_groups for a standalone group (in no cluster) reports nothing,
+  | since a standalone group has no tabs to rotate through
+  ) do
+    assert_equal({}, get_active_groups(STANDALONE_GROUP_ID), :standalone)
+  end
+
+  private
+
+  # GETs /active_groups/<id> as json, asserts 200, and returns the parsed body.
+  def get_active_groups(id)
+    get "/active_groups/#{id}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    assert status?(200), "status=#{status}"
+    JSON.parse(last_response.body)
+  end
+
+  # - - - - - - - - - - - - - - - - -
+  # Building saver data live (mirrors bin/create_cluster_kata.rb).
+
+  def create_cluster(display_names)
+    manifests = display_names.map { |name| group_manifest(name) }
+    saver_post('cluster_create', { manifests: manifests })
+  end
+
+  def child_group_ids(cluster_id)
+    saver_get('cluster_manifest', { id: cluster_id })['groups'].keys
+  end
+
+  def join_avatar(group_id)
+    saver_post('group_join', { id: group_id })
+  end
+
+  # Runs the kata's tests once (a green traffic-light), giving the avatar a
+  # non-creation event at index 1.
+  def give_traffic_light(kata_id)
+    files = saver_get('kata_event', { id: kata_id, index: 0 })['files']
+    saver_post('kata_ran_tests', {
+                 id: kata_id, index: 1, files: files,
+                 stdout: file('2 tests, 0 failures'), stderr: file(''), status: 0,
+                 summary: { 'colour' => 'green', 'predicted' => 'none' }
+               })
+  end
+
+  def group_manifest(display_name)
+    {
+      'display_name' => display_name,
+      'image_name' => 'cyberdojofoundation/bash_bats:53d0c9c',
+      'filename_extension' => ['.sh'],
+      'tab_size' => 4,
+      'exercise' => 'Fizz Buzz',
+      'version' => 2,
+      'highlight_filenames' => [],
+      'max_seconds' => 10,
+      'visible_files' => {
+        'hiker.sh' => file("echo hello\n"),
+        'cyber-dojo.sh' => file("./hiker.sh\n")
+      }
+    }
+  end
+
+  def file(content)
+    { 'content' => content, 'truncated' => false }
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  def saver_get(path, args)
+    saver_request(Net::HTTP::Get, path, args)
+  end
+
+  def saver_post(path, args)
+    saver_request(Net::HTTP::Post, path, args)
+  end
+
+  def saver_request(method_class, path, args)
+    host = ENV.fetch('CYBER_DOJO_SAVER_HOSTNAME', 'saver')
+    port = ENV.fetch('CYBER_DOJO_SAVER_PORT', 4537).to_i
+    uri = URI("http://#{host}:#{port}/#{path}")
+    req = method_class.new(uri)
+    req.content_type = 'application/json'
+    req.body = JSON.generate(args)
+    response = Net::HTTP.start(host, port) { |http| http.request(req) }
+    JSON.parse(response.body)[path.to_s]
+  end
+end

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -24,21 +24,21 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=',  24 ],
+    [ 'test.count',    stats['test_count'],    '>=',  27 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '<=',  0 ],
     [ 'test.errors',   stats['error_count'  ], '<=',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '<=',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 299 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 350 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '<=', 4   ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '<=', 0   ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 431 ],
-    [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=', 83  ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 62  ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 445 ],
+    [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=', 84  ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 64  ],
     [ 'code.branches.missed',  code_cov['branches']['missed'], '<=', 26  ],
   ]
 end


### PR DESCRIPTION
  When reviewing a cluster practice session, the auto-refresh rotation
  would dwell on child groups where nobody was working - freshly joined
  avatars with only their 'created' event and no test run. A reviewer
  had to sit through those idle tabs before rotation reached a group
  with actual activity.

  Rotation now only advances onto a group that has activity (an avatar
  with a non-creation event), skipping dormant tabs; if no other group
  is active it refreshes in place. All tabs stay visible either way.

  A new GET /active_groups/:id endpoint reports, per child group of the
  cluster the id resolves to, whether that group has any traffic-light.
  It is best-effort: any saver hiccup reports nothing active so the
  client simply refreshes in place rather than crashing.