### PR TITLE
Cover the server app completely, and fix what that uncovered

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,6 @@ AllCops:
   Exclude:
     - test/**/*
 
-Lint/IneffectiveAccessModifier:
-  Exclude:
-    - source/server/app/app_base.rb
-
 Metrics/AbcSize:
   Exclude:
     - source/server/app/app.rb

--- a/source/server/app/app_base.rb
+++ b/source/server/app/app_base.rb
@@ -71,8 +71,6 @@ class AppBase < Sinatra::Base
     send_file "#{ASSETS_DIR}/app.js"
   end
 
-  private
-
   def self.get_delegate(klass, name)
     get "/#{name}", provides: [:json] do
       respond_to do |format|
@@ -85,29 +83,6 @@ class AppBase < Sinatra::Base
     end
   end
 
-  def json_args
-    symbolized(json_payload)
-  end
-
-  def symbolized(h)
-    # named-args require symbolization
-    h.transform_keys(&:to_sym)
-  end
-
-  def json_payload
-    request.body.rewind
-    json_hash_parse(request.body.read)
-  end
-
-  def json_hash_parse(body)
-    json = body === '' ? {} : JSON.parse!(body)
-    raise 'body is not JSON Hash' unless json.instance_of?(Hash)
-
-    json
-  rescue JSON::ParserError
-    raise 'body is not JSON'
-  end
-
   set :show_exceptions, false
 
   error do
@@ -118,7 +93,7 @@ class AppBase < Sinatra::Base
       exception: {
         request: {
           path: request.path,
-          body: request.body.read
+          body: request.body&.read
         },
         backtrace: error.backtrace
       }

--- a/source/server/app/external_http.rb
+++ b/source/server/app/external_http.rb
@@ -5,9 +5,11 @@ class ExternalHttp
     KLASS::Get.new(uri)
   end
 
+  # :nocov: post is called only by the fixture scripts in test/scripts
   def post(uri)
     KLASS::Post.new(uri)
   end
+  # :nocov:
 
   def start(hostname, port, req)
     KLASS.start(hostname, port) do |http|

--- a/source/server/app/http_json_hash/requester.rb
+++ b/source/server/app/http_json_hash/requester.rb
@@ -15,11 +15,13 @@ module HttpJsonHash
       end
     end
 
+    # :nocov: post is called only by the fixture scripts in test/scripts
     def post(path, args)
       request(path, args) do |uri|
         @http.post(uri)
       end
     end
+    # :nocov:
 
     private
 

--- a/source/server/app/http_json_hash/unpacker.rb
+++ b/source/server/app/http_json_hash/unpacker.rb
@@ -13,10 +13,12 @@ module HttpJsonHash
       unpacked(response.body, path.to_s, args)
     end
 
+    # :nocov: post is called only by the fixture scripts in test/scripts
     def post(path, args)
       response = @requester.post(path, args)
       unpacked(response.body, path.to_s, args)
     end
+    # :nocov:
 
     private
 

--- a/test/scripts/create_v2_dashboard.rb
+++ b/test/scripts/create_v2_dashboard.rb
@@ -1,5 +1,11 @@
 # This has to run inside a docker-container so it can call the dependent services
 
+# This script is the only caller of the post half of the app's http chain:
+# ExternalHttp#post, HttpJsonHash::Requester#post and
+# HttpJsonHash::Unpacker#post. The dashboard itself only reads from the saver,
+# so those three methods are live code that no test exercises, and they carry
+# :nocov: markers pointing back here.
+
 require 'json'
 require 'securerandom'
 require_relative 'external_differ'

--- a/test/server/active_groups_test.rb
+++ b/test/server/active_groups_test.rb
@@ -1,8 +1,9 @@
 require_relative 'test_base'
+require_relative 'saver_data_builder'
 require 'json'
-require 'net/http'
 
 class ActiveGroupsTest < TestBase
+  include SaverDataBuilder
 
   # Cluster vntRcc is baked into the saver test data (see cluster_tabs_test.rb);
   # every one of its three child groups has avatars with traffic-lights.
@@ -18,7 +19,7 @@ class ActiveGroupsTest < TestBase
   | any avatar with a non-creation event; a child that has only been joined
   | (no test run) is reported false, a child with a run is reported true
   ) do
-    cluster_id = create_cluster(%w[LTF-A LTF-B])
+    cluster_id = create_cluster(['Bash, bats', 'Python, pytest'])
     active_child, inactive_child = child_group_ids(cluster_id)
     give_traffic_light(join_avatar(active_child))
     join_avatar(inactive_child) # joined only - no run, so no traffic-light
@@ -46,85 +47,33 @@ class ActiveGroupsTest < TestBase
     assert_equal({}, get_active_groups(STANDALONE_GROUP_ID), :standalone)
   end
 
+  # - - - - - - - - - - - - - - - - -
+
+  test 'a6t1v4', %w(
+  | GET /active_groups reports nothing when the saver cannot be reached, so an
+  | auto-refreshing cluster dashboard simply refreshes in place rather than
+  | breaking on a saver hiccup
+  ) do
+    saver = RaisingSaver.new
+    externals.instance_exec { @saver = saver }
+
+    assert_equal({}, get_active_groups(BAKED_CLUSTER_ID), :saver_unreachable)
+  end
+
   private
+
+  # Stands in for a saver that cannot be reached, so active_groups takes its
+  # best-effort rescue path.
+  class RaisingSaver
+    def id_chain(_id)
+      raise 'saver unreachable'
+    end
+  end
 
   # GETs /active_groups/<id> as json, asserts 200, and returns the parsed body.
   def get_active_groups(id)
     get "/active_groups/#{id}", {}, { 'HTTP_ACCEPT' => 'application/json' }
     assert status?(200), "status=#{status}"
     JSON.parse(last_response.body)
-  end
-
-  # - - - - - - - - - - - - - - - - -
-  # Building saver data live (mirrors bin/create_cluster_kata.rb).
-
-  def create_cluster(display_names)
-    manifests = display_names.map { |name| group_manifest(name) }
-    saver_post('cluster_create', { manifests: manifests })
-  end
-
-  def child_group_ids(cluster_id)
-    saver_get('cluster_manifest', { id: cluster_id })['groups'].keys
-  end
-
-  def join_avatar(group_id)
-    saver_post('group_join', { id: group_id })
-  end
-
-  # Runs the kata's tests once (a green traffic-light), giving the avatar a
-  # non-creation event. The saver assigns the event's index (head + 1), so no
-  # index is sent. laptop_id/tab_seq are the writer's idempotency key the saver
-  # now requires on every write.
-  def give_traffic_light(kata_id)
-    files = saver_get('kata_event', { id: kata_id, index: 0 })['files']
-    saver_post('kata_ran_tests', {
-                 id: kata_id, files: files,
-                 stdout: file('2 tests, 0 failures'), stderr: file(''), status: 0,
-                 summary: { 'colour' => 'green', 'predicted' => 'none' },
-                 laptop_id: '02cfdffb5c0c31221b837a153d1108e6cd19fd6cef11db27c8457a1e63caf46f',
-                 tab_seq: 1
-               })
-  end
-
-  def group_manifest(display_name)
-    {
-      'display_name' => display_name,
-      'image_name' => 'cyberdojofoundation/bash_bats:53d0c9c',
-      'filename_extension' => ['.sh'],
-      'tab_size' => 4,
-      'exercise' => 'Fizz Buzz',
-      'version' => 2,
-      'highlight_filenames' => [],
-      'max_seconds' => 10,
-      'visible_files' => {
-        'hiker.sh' => file("echo hello\n"),
-        'cyber-dojo.sh' => file("./hiker.sh\n")
-      }
-    }
-  end
-
-  def file(content)
-    { 'content' => content, 'truncated' => false }
-  end
-
-  # - - - - - - - - - - - - - - - - -
-
-  def saver_get(path, args)
-    saver_request(Net::HTTP::Get, path, args)
-  end
-
-  def saver_post(path, args)
-    saver_request(Net::HTTP::Post, path, args)
-  end
-
-  def saver_request(method_class, path, args)
-    host = ENV.fetch('CYBER_DOJO_SAVER_HOSTNAME', 'saver')
-    port = ENV.fetch('CYBER_DOJO_SAVER_PORT', 4537).to_i
-    uri = URI("http://#{host}:#{port}/#{path}")
-    req = method_class.new(uri)
-    req.content_type = 'application/json'
-    req.body = JSON.generate(args)
-    response = Net::HTTP.start(host, port) { |http| http.request(req) }
-    JSON.parse(response.body)[path.to_s]
   end
 end

--- a/test/server/avatars_progress_test.rb
+++ b/test/server/avatars_progress_test.rb
@@ -47,4 +47,53 @@ class AvatarsProgressTest < TestBase
     actual = avatars_progress
     assert_equal expected, actual
   end
+  # - - - - - - - - - - - - - - - - -
+
+  test '0D6b48', %w(
+  | an avatar that joined a v0/v1 group and never ran a test has only its
+  | creation event, and that event carries no colour, so the avatar has no
+  | lights at all and is left out of the progress list
+  ) do
+    saver = LegacyAvatarsSaver.new
+    externals.instance_exec { @saver = saver }
+    @params = { id: 'anyGroupId' }
+
+    expected = [
+      { id: 'rUqcey', avatar_index: 26, colour: :green, progress: '' }
+    ]
+    assert_equal expected, avatars_progress
+  end
+
+  private
+
+  # Stands in for the saver with two avatars shaped as v0/v1 stores them. The
+  # first joined and never ran, so its only event is the creation one, which
+  # carries just event and time - no colour. (v2 gives that event colour
+  # 'create', which is why only legacy data reaches the no-lights case, and
+  # PolyFiller never adds a colour that was not stored.) The second ran once.
+  class LegacyAvatarsSaver
+    CREATED_AT = [2019, 1, 19, 12, 41, 0, 406370].freeze
+    RAN_AT = [2019, 1, 19, 12, 42, 0, 0].freeze
+
+    JOINED = {
+      '11' => { 'id' => 'k5ZTk0',
+                'events' => [{ 'event' => 'created', 'time' => CREATED_AT }] },
+      '26' => { 'id' => 'rUqcey',
+                'events' => [{ 'event' => 'created', 'time' => CREATED_AT },
+                             { 'colour' => 'green', 'index' => 1, 'time' => RAN_AT }] }
+    }.freeze
+
+    def group_joined(_id)
+      JOINED
+    end
+
+    def group_manifest(_id)
+      { 'progress_regexs' => [] }
+    end
+
+    def katas_events(_ids, _indexes)
+      { 'rUqcey' => { '1' => { 'stdout' => { 'content' => 'OK' },
+                               'stderr' => { 'content' => '' } } } }
+    end
+  end
 end

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -24,22 +24,22 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=',  28 ],
+    [ 'test.count',    stats['test_count'],    '>=',  48 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '==',  0 ],
     [ 'test.errors',   stats['error_count'  ], '==',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '==',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 348 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 607 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '==',   0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '==',   0 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '==',   0 ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 454 ],
-    [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=',  84 ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=',  66 ],
-    [ 'code.branches.missed',  code_cov['branches']['missed'], '<=',  26 ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 433 ],
+    [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '==',   0 ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=',  64 ],
+    [ 'code.branches.missed',  code_cov['branches']['missed'], '==',   0 ],
   ]
 end
 

--- a/test/server/cluster_tabs_test.rb
+++ b/test/server/cluster_tabs_test.rb
@@ -68,7 +68,29 @@ class ClusterTabsTest < TestBase
     assert_equal "/dashboard/show/#{CLUSTER_ID}?sort_by=lights&group_id=9bYWLV", redirect_location
   end
 
+  # - - - - - - - - - - - - - - - - -
+
+  test 'c1u5b7', %w(
+  | an id resolving to neither a cluster nor a group - a standalone kata - is
+  | rendered as a single group keyed on the requested id itself, with no tabs
+  ) do
+    saver = KataOnlyChainSaver.new
+    externals.instance_exec { @saver = saver }
+
+    html = show_html('kAtA01')
+    assert_includes html, 'let _groupId = "kAtA01";', html
+    assert_includes html, 'cd.tabs = () => [];', html
+  end
+
   private
+
+  # Stands in for the saver, answering an id-chain holding neither a cluster nor
+  # a group, which is what a standalone kata resolves to.
+  class KataOnlyChainSaver
+    def id_chain(id)
+      [{ 'type' => 'kata', 'id' => id }]
+    end
+  end
 
   # The Location header of the last response.
   def redirect_location

--- a/test/server/error_handler_test.rb
+++ b/test/server/error_handler_test.rb
@@ -1,0 +1,148 @@
+require_relative 'test_base'
+require 'json'
+require 'ostruct'
+
+class ErrorHandlerTest < TestBase
+
+  # The saver http adapter is stubbed in both tests, so this id is never
+  # resolved - it only has to be a well-formed id.
+  GROUP_ID = '9aZUWE'
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'e5r8h1', %w(
+  | when a saver call answers a body that is not JSON, the route 500s with a
+  | json diagnostic naming the failed http service, and logs that same
+  | diagnostic to stdout
+  ) do
+    externals.instance_exec { @saver_http = HttpAdapterStub.new('xxxx') }
+
+    exception = assert_500_diagnostic['exception']
+    assert_equal %w[backtrace http_service request], exception.keys.sort, exception
+    assert_equal({ 'path' => '/diff_summary', 'body' => nil },
+                 exception['request'], exception)
+
+    service = exception['http_service']
+    assert_equal %w[args body message name path], service.keys.sort, service
+    assert_equal 'diff_summary', service['path'], service
+    assert_equal 'ExternalSaver', service['name'], service
+    assert_equal 'xxxx', service['body'], service
+    assert_equal({ 'id' => GROUP_ID, 'was_index' => 1, 'now_index' => 2 },
+                 service['args'], service)
+    expected = [
+      'body is not JSON',
+      'diff_summary',
+      'xxxx'
+    ]
+    assert_equal expected.join("\n"), service['message'], service
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'e5r8h2', %w(
+  | when a saver call raises something that is not a ServiceError, the route
+  | 500s with a json diagnostic carrying the exception's own message instead
+  | of any http-service detail
+  ) do
+    externals.instance_exec { @saver_http = HttpRaiserStub.new }
+
+    exception = assert_500_diagnostic['exception']
+    assert_equal %w[backtrace message request], exception.keys.sort, exception
+    assert_equal '42', exception['message'], exception
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'e5r8h3', %w(
+  | when a saver call answers valid JSON that is not a Hash, the diagnostic
+  | names that as the http-service failure
+  ) do
+    externals.instance_exec { @saver_http = HttpAdapterStub.new('42') }
+
+    service = assert_500_diagnostic['exception']['http_service']
+    assert_equal '42', service['body'], service
+    expected = [
+      'body is not JSON Hash',
+      'diff_summary',
+      '42'
+    ]
+    assert_equal expected.join("\n"), service['message'], service
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'e5r8h4', %w(
+  | when a saver call answers a JSON Hash that lacks the called method's own
+  | key, the diagnostic names that as the http-service failure
+  ) do
+    body = '{"wibble":42}'
+    externals.instance_exec { @saver_http = HttpAdapterStub.new(body) }
+
+    service = assert_500_diagnostic['exception']['http_service']
+    assert_equal body, service['body'], service
+    expected = [
+      'body is missing :path key',
+      'diff_summary',
+      body
+    ]
+    assert_equal expected.join("\n"), service['message'], service
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'e5r8h5', %w(
+  | when the failing request carries a body, the diagnostic echoes that body.
+  | A bodyless request has no rack.input at all under rack 3, which is why the
+  | handler reads it with safe navigation
+  ) do
+    externals.instance_exec { @saver_http = HttpAdapterStub.new('xxxx') }
+    request_body = 'some-request-body'
+
+    exception = assert_500_diagnostic(JSON_HEADERS.merge(input: request_body))['exception']
+    assert_equal({ 'path' => '/diff_summary', 'body' => request_body },
+                 exception['request'], exception)
+  end
+
+  private
+
+  # GETs /diff_summary, asserts a 500 json response whose body is exactly the
+  # diagnostic the handler also logs to stdout, and returns it parsed.
+  JSON_HEADERS = { 'HTTP_ACCEPT' => 'application/json' }.freeze
+
+  def assert_500_diagnostic(env = JSON_HEADERS)
+    stdout, stderr = capture_io do
+      get "/diff_summary?id=#{GROUP_ID}&was_index=1&now_index=2", {}, env
+    end
+    assert status?(500), "status=#{status}"
+    assert_equal 'application/json', content_type, content_type
+    assert_equal '', stderr, :stderr
+    assert_equal last_response.body, stdout.chomp, :stdout
+    JSON.parse(last_response.body)
+  end
+
+  # An http adapter whose every response carries the given body, so the
+  # unpacker's JSON parse of it decides what happens next.
+  class HttpAdapterStub
+    def initialize(body)
+      @body = body
+    end
+
+    def get(_uri)
+      OpenStruct.new
+    end
+
+    def start(_hostname, _port, _req)
+      self
+    end
+
+    attr_reader :body
+  end
+
+  # An http adapter that fails before any response exists, so the error
+  # reaching the handler is not a ServiceError.
+  class HttpRaiserStub
+    def get(_uri)
+      raise '42'
+    end
+  end
+end

--- a/test/server/heartbeat_test.rb
+++ b/test/server/heartbeat_test.rb
@@ -1,0 +1,186 @@
+require_relative 'test_base'
+require_relative 'saver_data_builder'
+require 'json'
+
+class HeartbeatTest < TestBase
+  include SaverDataBuilder
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'h4b7t1', %w(
+  | GET /heartbeat/<group-id> returns, for each avatar that has activity, its
+  | kata_id and its traffic-lights bucketed into minute columns, plus one
+  | time_tick per column. An avatar that has only joined, with no test run,
+  | has no activity so it is absent.
+  ) do
+    group_id = create_group('Bash, bats')
+    ran_kata_id = join_avatar(group_id)
+    give_traffic_light(ran_kata_id)
+    join_avatar(group_id) # joined only - no run, so no activity, so absent
+
+    response = get_heartbeat(group_id)
+    assert_equal %w[avatars time_ticks], response.keys.sort, response
+
+    avatars = response['avatars']
+    assert_equal 1, avatars.size, avatars
+    avatar = avatars.values[0]
+    assert_equal %w[kata_id lights], avatar.keys.sort, avatar
+    assert_equal ran_kata_id, avatar['kata_id'], avatar
+
+    lights = avatar['lights']
+    assert_equal ['0'], lights.keys, lights
+    column = lights['0']
+    assert_equal 1, column.size, column
+
+    light = column[0]
+    assert_equal %w[colour index major_index minor_index previous_index time],
+                 light.keys.sort, light
+    assert_equal 'green', light['colour'], light
+    assert_equal 1, light['index'], light
+    assert_equal 0, light['previous_index'], light
+
+    assert_equal ['0'], response['time_ticks'].keys, response['time_ticks']
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'h4b7t2', %w(
+  | GET /heartbeat?minute_columns=false widens one column from a minute to
+  | effectively forever, so a lone light still sits in column 0 but that
+  | column's time_tick spans 365000 days instead of one minute
+  ) do
+    group_id = create_group('Bash, bats')
+    give_traffic_light(join_avatar(group_id))
+
+    assert_equal({ '0' => [0, 0, 1] },
+                 get_heartbeat(group_id)['time_ticks'])
+    assert_equal({ '0' => [365_000, 0, 0] },
+                 get_heartbeat(group_id, 'minute_columns=false')['time_ticks'])
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'h4b7t3', %w(
+  | GET /heartbeat?detailed=true also shows inter-test events, those with a
+  | non-zero index that are not traffic-lights, where the default view shows
+  | traffic-lights alone
+  ) do
+    group_id = create_group('Bash, bats')
+    kata_id = join_avatar(group_id)
+    give_traffic_light(kata_id)
+    edit_a_file(kata_id)
+
+    assert_equal 1, lights_of(get_heartbeat(group_id)).size, 'plain'
+    assert_equal 2, lights_of(get_heartbeat(group_id, 'detailed=true')).size, 'detailed'
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'h4b7t4', %w(
+  | a traffic-light's json carries predicted, revert and checkout only when its
+  | own event has them, so a predicted run, a revert and a checkout each add
+  | exactly one field to the base light
+  ) do
+    group_id = create_group('Bash, bats')
+    kata_id = join_avatar(group_id)
+    give_predicted_light(kata_id)
+    give_reverted_light(kata_id)
+    give_checked_out_light(kata_id)
+
+    lights = lights_of(get_heartbeat(group_id))
+    assert_equal 3, lights.size, lights
+    base = %w[colour index major_index minor_index previous_index time]
+    assert_equal [['predicted'], ['revert'], ['checkout']],
+                 lights.map { |light| light.keys.sort - base }, lights
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  CREATED = [2026, 7, 22, 9, 0, 0, 0].freeze
+  FIRST_LIGHT_TIME = [2026, 7, 22, 9, 0, 30, 0].freeze
+  LATER_LIGHT_TIME = [2026, 7, 22, 9, 10, 30, 0].freeze
+  NOW = [2026, 7, 22, 9, 11, 0, 0].freeze
+
+  test 'h4b7t5', %w(
+  | when two lights are further apart than the uncollapsed maximum, the columns
+  | between them collapse into a single column carrying the count of columns it
+  | stands for, and that column's time_tick is that same collapsed count rather
+  | than a days/hours/minutes triple
+  ) do
+    events = [
+      { 'index' => 0, 'colour' => 'create', 'time' => CREATED },
+      { 'index' => 1, 'colour' => 'green', 'major_index' => 1, 'minor_index' => 0,
+        'time' => FIRST_LIGHT_TIME },
+      { 'index' => 2, 'colour' => 'red', 'major_index' => 2, 'minor_index' => 0,
+        'time' => LATER_LIGHT_TIME }
+    ]
+    joined = { '11' => { 'id' => 'kAtA01', 'events' => events } }
+    saver = SaverStub.new(joined, { 'created' => CREATED })
+    time = TimeStub.new(NOW)
+    externals.instance_exec { @saver = saver; @time = time }
+
+    expected = {
+      'time_ticks' => {
+        '0' => [0, 0, 1],
+        '1' => { 'collapsed' => 9 },
+        '10' => [0, 0, 11]
+      },
+      'avatars' => {
+        '11' => {
+          'kata_id' => 'kAtA01',
+          'lights' => {
+            '0' => [{ 'previous_index' => 0, 'index' => 1, 'major_index' => 1,
+                      'minor_index' => 0, 'colour' => 'green',
+                      'time' => FIRST_LIGHT_TIME }],
+            '1' => { 'collapsed' => 9 },
+            '10' => [{ 'previous_index' => 1, 'index' => 2, 'major_index' => 2,
+                       'minor_index' => 0, 'colour' => 'red',
+                       'time' => LATER_LIGHT_TIME }]
+          }
+        }
+      }
+    }
+    assert_equal expected, get_heartbeat('anyGroupId')
+  end
+
+  private
+
+  # GETs /heartbeat/<id> as json, asserts 200, and returns the parsed body.
+  def get_heartbeat(id, query = '')
+    get "/heartbeat/#{id}?#{query}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    assert status?(200), "status=#{status}"
+    JSON.parse(last_response.body)
+  end
+
+  # Every event the response shows, across all avatars and columns, index order.
+  def lights_of(response)
+    response['avatars'].values.flat_map do |avatar|
+      avatar['lights'].values.select { |column| column.is_a?(Array) }.flatten
+    end.sort_by { |light| light['index'] }
+  end
+  # Stands in for the saver so a test owns every light's time, which the real
+  # saver stamps from its own clock. gather needs only these two calls.
+  class SaverStub
+    def initialize(joined, manifest)
+      @joined = joined
+      @manifest = manifest
+    end
+
+    def group_joined(_id)
+      @joined
+    end
+
+    def group_manifest(_id)
+      @manifest
+    end
+  end
+
+  # Stands in for ExternalTime so "now" is fixed relative to the light times.
+  class TimeStub
+    def initialize(now)
+      @now = now
+    end
+
+    attr_reader :now
+  end
+end

--- a/test/server/probes_test.rb
+++ b/test/server/probes_test.rb
@@ -1,0 +1,111 @@
+require_relative 'test_base'
+require 'json'
+require 'ostruct'
+
+class ProbesTest < TestBase
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b1', %w(
+  | GET /alive? has status 200 and returns true, and nothing else
+  ) do
+    assert_probe_200('alive?') do |response|
+      assert_equal ['alive?'], response.keys, response
+      assert true?(response['alive?']), response
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b2', %w(
+  | when the saver is ready
+  | GET /ready? has status 200 and returns true, and nothing else
+  ) do
+    assert_probe_200('ready?') do |response|
+      assert_equal ['ready?'], response.keys, response
+      assert true?(response['ready?']), response
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b3', %w(
+  | when the saver is not ready
+  | GET /ready? has status 200 and returns false, and nothing else
+  ) do
+    externals.instance_exec { @saver = STUB_READY_FALSE }
+    assert_probe_200('ready?') do |response|
+      assert_equal ['ready?'], response.keys, response
+      assert false?(response['ready?']), response
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b4', %w(
+  | GET /alive? is used by external k8s probes, so obeys Postel's Law
+  | and ignores any passed arguments
+  ) do
+    assert_probe_200('alive?arg=unused') do |response|
+      assert_equal ['alive?'], response.keys, response
+      assert true?(response['alive?']), response
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b5', %w(
+  | GET /ready? is used by external k8s probes, so obeys Postel's Law
+  | and ignores any passed arguments
+  ) do
+    assert_probe_200('ready?arg=unused') do |response|
+      assert_equal ['ready?'], response.keys, response
+      assert true?(response['ready?']), response
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p9r2b6', %w(
+  | GET /sha has status 200 and returns the 40-char lowercase git commit sha
+  | baked into the image at build time, and nothing else
+  ) do
+    assert_probe_200('sha') do |response|
+      assert_equal ['sha'], response.keys, response
+      assert git_sha?(response['sha']), response['sha']
+    end
+  end
+
+  private
+
+  STUB_READY_FALSE = OpenStruct.new(ready?: false)
+
+  # GETs the probe path as json, asserts 200 and no stray output, then yields
+  # the parsed body.
+  def assert_probe_200(path, &block)
+    stdout, stderr = capture_io do
+      get "/#{path}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    end
+    assert status?(200), "status=#{status}"
+    assert_equal '', stderr, :stderr
+    assert_equal '', stdout, :stdout
+    block.call(JSON.parse(last_response.body))
+  end
+
+  # True when obj is exactly true, rather than merely truthy.
+  def true?(obj)
+    obj.instance_of?(TrueClass)
+  end
+
+  # True when obj is exactly false, rather than merely falsy.
+  def false?(obj)
+    obj.instance_of?(FalseClass)
+  end
+
+  # True when str is a 40-character lowercase hex git commit sha.
+  def git_sha?(str)
+    str.instance_of?(String) &&
+      str.size == 40 &&
+      str.chars.all? { |ch| '0123456789abcdef'.include?(ch) }
+  end
+end

--- a/test/server/progress_test.rb
+++ b/test/server/progress_test.rb
@@ -1,0 +1,37 @@
+require_relative 'test_base'
+require_relative 'saver_data_builder'
+require 'json'
+
+class ProgressTest < TestBase
+  include SaverDataBuilder
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'p2g5s1', %w(
+  | GET /progress/<group-id> returns one entry per joined avatar, carrying its
+  | kata id, avatar index, latest colour and the progress string matched out of
+  | that run's output. An avatar that has only joined still appears, with the
+  | colour 'create' of its creation event.
+  ) do
+    group_id = create_group('Bash, bats')
+    ran_kata_id = join_avatar(group_id)
+    give_traffic_light(ran_kata_id)
+    joined_kata_id = join_avatar(group_id)
+
+    index_of = saver_get('group_joined', { id: group_id })
+               .to_h { |index, o| [o['id'], index.to_i] }
+
+    get "/progress/#{group_id}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    assert status?(200), "status=#{status}"
+
+    expected = [
+      { 'id' => ran_kata_id, 'avatar_index' => index_of[ran_kata_id],
+        'colour' => 'green', 'progress' => '' },
+      { 'id' => joined_kata_id, 'avatar_index' => index_of[joined_kata_id],
+        'colour' => 'create', 'progress' => '' }
+    ]
+    by_index = ->(katas) { katas.sort_by { |kata| kata['avatar_index'] } }
+    assert_equal by_index.call(expected),
+                 by_index.call(JSON.parse(last_response.body)['katas'])
+  end
+end

--- a/test/server/saver_data_builder.rb
+++ b/test/server/saver_data_builder.rb
@@ -1,0 +1,140 @@
+require 'json'
+require 'net/http'
+
+# Builds cyber-dojo entities (clusters, groups, avatars, traffic-lights)
+# directly in the saver over HTTP, so a test can set up exactly the state it
+# needs and then assert exact values rather than shapes. Mirrors
+# bin/create_cluster_kata.rb.
+module SaverDataBuilder
+
+  # Creates a cluster with one child group per display-name, returning its id.
+  def create_cluster(display_names)
+    manifests = display_names.map { |name| group_manifest(name) }
+    saver_post('cluster_create', { manifests: manifests })
+  end
+
+  # The ids of the cluster's child groups, one per LTF.
+  def child_group_ids(cluster_id)
+    saver_get('cluster_manifest', { id: cluster_id })['groups'].keys
+  end
+
+  # Creates a standalone group (in no cluster) for the display-name, returning
+  # its id. Use this rather than a cluster when a test needs only one group: a
+  # cluster requires 2..5 LTFs (see the saver's Cluster#create).
+  def create_group(display_name)
+    saver_post('group_create', { manifest: group_manifest(display_name) })
+  end
+
+  # Joins one avatar into the group, returning its kata id.
+  def join_avatar(group_id)
+    saver_post('group_join', { id: group_id })
+  end
+
+  # The writer's idempotency key the saver requires on every write. One notional
+  # laptop makes all these writes, with tab_seq distinguishing them.
+  LAPTOP_ID = '02cfdffb5c0c31221b837a153d1108e6cd19fd6cef11db27c8457a1e63caf46f'.freeze
+
+  # The arguments every test-run event write shares, carrying the given summary.
+  # tab_seq must differ per write, since laptop_id plus tab_seq is the saver's
+  # idempotency key. The name must not start with test_ - minitest collects any
+  # such method as a test and calls it with no arguments.
+  def run_test_event_args(kata_id, summary, tab_seq)
+    files = saver_get('kata_event', { id: kata_id, index: 0 })['files']
+    {
+      id: kata_id, files: files,
+      stdout: file('2 tests, 0 failures'), stderr: file(''), status: 0,
+      summary: summary, laptop_id: LAPTOP_ID, tab_seq: tab_seq
+    }
+  end
+
+  # Runs the kata's tests once (a green traffic-light), giving the avatar a
+  # non-creation event. The saver assigns the event's index (head + 1).
+  def give_traffic_light(kata_id)
+    saver_post('kata_ran_tests',
+               run_test_event_args(kata_id, { 'colour' => 'green', 'predicted' => 'none' }, 1))
+  end
+
+  # A traffic-light whose event carries a prediction that turned out right.
+  def give_predicted_light(kata_id)
+    saver_post('kata_predicted_right',
+               run_test_event_args(kata_id, { 'colour' => 'green', 'predicted' => 'green' }, 3))
+  end
+
+  # A traffic-light whose event carries the [id, index] it was reverted to.
+  def give_reverted_light(kata_id)
+    saver_post('kata_reverted',
+               run_test_event_args(kata_id, { 'colour' => 'red', 'revert' => [kata_id, 1] }, 4))
+  end
+
+  # A traffic-light whose event carries what it was checked out from.
+  def give_checked_out_light(kata_id)
+    saver_post('kata_checked_out',
+               run_test_event_args(kata_id,
+                             { 'colour' => 'amber',
+                               'checkout' => { 'id' => kata_id, 'index' => 1 } }, 5))
+  end
+
+  # Edits one of the kata's files, giving the avatar an inter-test event: a
+  # non-zero index that is not a traffic-light. Only the detailed dashboard view
+  # shows these.
+  def edit_a_file(kata_id)
+    files = saver_get('kata_event', { id: kata_id, index: 0 })['files']
+    files['hiker.sh']['content'] += "\n# edited\n"
+    saver_post('kata_file_edit', {
+                 id: kata_id, files: files,
+                 laptop_id: LAPTOP_ID, tab_seq: 2
+               })
+  end
+
+  # A group manifest for the given LTF display-name, which must be a real one
+  # (eg 'Bash, bats', 'Python, pytest', 'Ruby, MiniTest'). Every LTF shares the
+  # same Bash/bats image and files; only the display-name differs. That mirrors
+  # bin/create_cluster_kata.rb and holds for the same reason: one known
+  # toolchain keeps generated runs reliable, and what these tests exercise is
+  # per-LTF grouping rather than three distinct toolchains.
+  def group_manifest(display_name)
+    {
+      'display_name' => display_name,
+      'image_name' => 'cyberdojofoundation/bash_bats:53d0c9c',
+      'filename_extension' => ['.sh'],
+      'tab_size' => 4,
+      'exercise' => 'Fizz Buzz',
+      'version' => 2,
+      'highlight_filenames' => [],
+      'max_seconds' => 10,
+      'visible_files' => {
+        'hiker.sh' => file("echo hello\n"),
+        'cyber-dojo.sh' => file("./hiker.sh\n")
+      }
+    }
+  end
+
+  # One entry of a manifest's visible_files.
+  def file(content)
+    { 'content' => content, 'truncated' => false }
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  # GETs the saver path, returning the value under its own key.
+  def saver_get(path, args)
+    saver_request(Net::HTTP::Get, path, args)
+  end
+
+  # POSTs to the saver path, returning the value under its own key.
+  def saver_post(path, args)
+    saver_request(Net::HTTP::Post, path, args)
+  end
+
+  # Sends one json request to the saver and unwraps its path-keyed response.
+  def saver_request(method_class, path, args)
+    host = ENV.fetch('CYBER_DOJO_SAVER_HOSTNAME', 'saver')
+    port = ENV.fetch('CYBER_DOJO_SAVER_PORT', 4537).to_i
+    uri = URI("http://#{host}:#{port}/#{path}")
+    req = method_class.new(uri)
+    req.content_type = 'application/json'
+    req.body = JSON.generate(args)
+    response = Net::HTTP.start(host, port) { |http| http.request(req) }
+    JSON.parse(response.body)[path.to_s]
+  end
+end


### PR DESCRIPTION
  The server suite sat at 84 uncovered lines and 26 uncovered branches, and
  check_test_metrics.rb pinned its thresholds at exactly those figures - a
  snapshot of whatever happened to be true rather than a bar to hold. Closing
  the gaps turned up a bug, some dead code and some live code no test can
  reach, because an untested branch and a broken one hide each other.

  The bug: the error handler read request.body.read, but rack 3 omits
  rack.input entirely for a bodyless request, so every error reaching the
  handler became a NoMethodError from inside the handler and the diagnostic it
  exists to print was never produced. Creator's copy already guards this with
  &. - dashboard's did not. Nothing had ever exercised the handler, so nothing
  had ever noticed.

  The dead code: json_args, symbolized, json_payload and json_hash_parse were
  inherited from a repo that serves POSTs. Dashboard has no POST route, so
  nothing could reach them. Deleting them also made a private modifier useless
  and made the Lint/IneffectiveAccessModifier exclusion in .rubocop.yml
  unnecessary, since that cop only fired because private sat in front of
  def self.get_delegate, where it never applied.

  The unreachable-by-test code: the post half of the http chain
  (ExternalHttp#post, Requester#post, Unpacker#post) is called only by
  test/scripts/create_v2_dashboard.rb, which bakes the saver fixtures and runs
  outside the suite. That is live code with a real caller, so it carries
  :nocov: markers and the rationale is recorded once, at the caller.

  Two findings worth keeping. avatars_progress's "next if lights == []" is
  reachable only for v0/v1 data: those store just event and time on a creation
  event, where v2 adds colour 'create', and PolyFiller never invents a colour
  that was not stored. Neither baked legacy fixture holds a joined-but-never-ran
  avatar, so that case is driven by a stub shaped from the real k5ZTk0 event.
  And the collapsed-column branches need two lights further apart than the
  uncollapsed maximum with a light after the gap, since TdGapper#strip discards
  a trailing collapsed column - times the real saver stamps from its own clock,
  hence a saver stub there too.

  New tests: probes, heartbeat, progress, error handler, plus a shared
  SaverDataBuilder that builds v2 groups, avatars and events live so
  assertions can be exact rather than shape-based. active_groups_test loses its
  copy of those builders.

  The gate now holds the result rather than describing it: code.lines.missed
  and code.branches.missed move from "<= 84" and "<= 26" to "== 0", so any
  regression fails. test.branches.total stays pinned at 0 - test code contains
  no conditionals - which cost two helper rewrites to preserve.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>