### PR TITLE
Cap line length at 80, matching creator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,17 @@ AllCops:
   Exclude:
     - test/**/*
 
+# Rubocop's default of 120 is far longer than this codebase needs. Long lines
+# here come from long identifiers rather than dense logic, so they gain nothing
+# from the extra room.
+#
+# This also works with Style/IfUnlessModifier, which demands the one-line
+# modifier form whenever it fits inside this Max, so the ceiling is what pushes
+# a long "do_something(...) if condition" out into an if/end block, the more
+# readable shape once the line gets long.
+Layout/LineLength:
+  Max: 80
+
 Metrics/AbcSize:
   Exclude:
     - source/server/app/app.rb

--- a/bin/create_cluster_kata.rb
+++ b/bin/create_cluster_kata.rb
@@ -104,10 +104,29 @@ RED_STDOUT = "1..2\nnot ok 1 1 gives 1\n" \
 
 GREEN_STDOUT = "1..2\nok 1 1 gives 1\nok 2 3 gives Fizz\n\n2 tests, 0 failures"
 
-HIKER_LINE_FOR = { 'red' => RED_LINE, 'amber' => AMBER_LINE, 'green' => GREEN_LINE }.freeze
-STDOUT_FOR     = { 'red' => RED_STDOUT, 'amber' => '', 'green' => GREEN_STDOUT }.freeze
-STDERR_FOR     = { 'red' => '', 'amber' => "./hiker.sh: line 10: `${n': bad substitution", 'green' => '' }.freeze
-STATUS_FOR     = { 'red' => 1, 'amber' => 1, 'green' => 0 }.freeze
+HIKER_LINE_FOR = {
+  'red' => RED_LINE,
+  'amber' => AMBER_LINE,
+  'green' => GREEN_LINE
+}.freeze
+
+STDOUT_FOR = {
+  'red' => RED_STDOUT,
+  'amber' => '',
+  'green' => GREEN_STDOUT
+}.freeze
+
+STDERR_FOR = {
+  'red' => '',
+  'amber' => "./hiker.sh: line 10: `${n': bad substitution",
+  'green' => ''
+}.freeze
+
+STATUS_FOR = {
+  'red' => 1,
+  'amber' => 1,
+  'green' => 0
+}.freeze
 
 # The manifest fields shared by every LTF; only display_name, visible_files and
 # (optionally) progress_regexs differ per child group.
@@ -206,8 +225,11 @@ end
 # Runs the tests once for the writer, having substituted hiker.sh to produce
 # the given colour.
 def traffic_light(kata_id, files, original_hiker, hue, writer)
-  files['hiker.sh']['content'] = original_hiker.sub(GREEN_LINE, HIKER_LINE_FOR[hue])
-  saver_post('kata_ran_tests', ran_tests_args(kata_id, files, hue, writer.laptop_id, writer.next_tab_seq))
+  files['hiker.sh']['content'] =
+    original_hiker.sub(GREEN_LINE, HIKER_LINE_FOR[hue])
+  args = ran_tests_args(kata_id, files, hue, writer.laptop_id,
+                        writer.next_tab_seq)
+  saver_post('kata_ran_tests', args)
   log_dot
 end
 
@@ -219,7 +241,8 @@ def create_avatar(group_id)
   original_hiker = files['hiker.sh']['content']
   writer = Writer.new
   rand(LIGHTS_PER_AVATAR).times do
-    traffic_light(kata_id, files, original_hiker, %w[red amber green].sample, writer)
+    hue = %w[red amber green].sample
+    traffic_light(kata_id, files, original_hiker, hue, writer)
   end
 end
 

--- a/bin/create_group_kata.rb
+++ b/bin/create_group_kata.rb
@@ -2,7 +2,8 @@
 
 # Connects to the saver (its port is exposed to the host) and creates a v2
 # group kata: Bash, bats / Fizz Buzz, with 16 avatars joined.
-# Each avatar gets a random number of test runs with random traffic-light colours.
+# Each avatar gets a random number of test runs with random traffic-light
+# colours.
 # Prints the group ID on completion.
 
 require 'json'
@@ -95,15 +96,35 @@ TEXT
 RED_STDOUT = "1..4\nnot ok 1 1 gives 1\n" \
              "# (in test file ./test_hiker.sh, line 6)\n" \
              "#   `[ \"$(fizz_buzz 1)\" = \"1\" ]' failed\n" \
-             "ok 2 3 gives Fizz\nok 3 5 gives Buzz\nok 4 15 gives FizzBuzz\n\n4 tests, 1 failure"
+             "ok 2 3 gives Fizz\nok 3 5 gives Buzz\n" \
+             "ok 4 15 gives FizzBuzz\n\n4 tests, 1 failure"
 
 GREEN_STDOUT = "1..4\nok 1 1 gives 1\nok 2 3 gives Fizz\nok 3 5 gives Buzz\n" \
                "ok 4 15 gives FizzBuzz\n\n4 tests, 0 failures"
 
-HIKER_LINE_FOR = { 'red' => RED_LINE, 'amber' => AMBER_LINE, 'green' => GREEN_LINE }.freeze
-STDOUT_FOR     = { 'red' => RED_STDOUT, 'amber' => '', 'green' => GREEN_STDOUT }.freeze
-STDERR_FOR     = { 'red' => '', 'amber' => "./hiker.sh: line 10: `${n': bad substitution", 'green' => '' }.freeze
-STATUS_FOR     = { 'red' => 1, 'amber' => 1, 'green' => 0 }.freeze
+HIKER_LINE_FOR = {
+  'red' => RED_LINE,
+  'amber' => AMBER_LINE,
+  'green' => GREEN_LINE
+}.freeze
+
+STDOUT_FOR = {
+  'red' => RED_STDOUT,
+  'amber' => '',
+  'green' => GREEN_STDOUT
+}.freeze
+
+STDERR_FOR = {
+  'red' => '',
+  'amber' => "./hiker.sh: line 10: `${n': bad substitution",
+  'green' => ''
+}.freeze
+
+STATUS_FOR = {
+  'red' => 1,
+  'amber' => 1,
+  'green' => 0
+}.freeze
 
 MANIFEST = {
   'display_name' => 'Bash, bats',
@@ -190,22 +211,29 @@ class Writer
 end
 
 def traffic_light(id, files, original_hiker, hue, writer)
-  files['hiker.sh']['content'] = original_hiker.sub(GREEN_LINE, HIKER_LINE_FOR[hue])
-  saver_post('kata_ran_tests', ran_tests_args(id, files, hue, writer.laptop_id, writer.next_tab_seq))
+  files['hiker.sh']['content'] =
+    original_hiker.sub(GREEN_LINE, HIKER_LINE_FOR[hue])
+  args = ran_tests_args(id, files, hue, writer.laptop_id, writer.next_tab_seq)
+  saver_post('kata_ran_tests', args)
   log_dot
 end
 
 COMMENT_LINE = '# ...'
 
 # Each edit is a distinct write, so the writer's tab_seq advances per edit.
+# Appends a comment to the named file and posts that edit as one write.
+def append_comment(id, files, filename, writer)
+  files[filename]['content'] += "#{COMMENT_LINE}\n"
+  saver_post('kata_file_edit',
+             { id: id, files: files,
+               laptop_id: writer.laptop_id, tab_seq: writer.next_tab_seq })
+  log_dot
+end
+
 def extra_file_edits(id, files, writer)
   rand(1..2).times do
-    files['hiker.sh']['content'] += "#{COMMENT_LINE}\n"
-    saver_post('kata_file_edit', { id: id, files: files, laptop_id: writer.laptop_id, tab_seq: writer.next_tab_seq })
-    log_dot
-    files['test_hiker.sh']['content'] += "#{COMMENT_LINE}\n"
-    saver_post('kata_file_edit', { id: id, files: files, laptop_id: writer.laptop_id, tab_seq: writer.next_tab_seq })
-    log_dot
+    append_comment(id, files, 'hiker.sh', writer)
+    append_comment(id, files, 'test_hiker.sh', writer)
   end
 end
 
@@ -216,7 +244,8 @@ def rag_cycle(id, files, original_hiker, writer)
   end
 end
 
-# One avatar is one writer; its tab_seq counts every write across all its cycles.
+# One avatar is one writer; its tab_seq counts every write across all its
+# cycles.
 def create_avatar(gid, count)
   id = saver_post('group_join', { id: gid })
   files = saver_get('kata_event', { id: id, index: 0 })['files']

--- a/bin/rewrite_demo_timestamps.rb
+++ b/bin/rewrite_demo_timestamps.rb
@@ -49,7 +49,8 @@ def random_gap(index)
 end
 
 def time_array(time)
-  [time.year, time.month, time.day, time.hour, time.min, time.sec, rand(1_000_000)]
+  [time.year, time.month, time.day,
+   time.hour, time.min, time.sec, rand(1_000_000)]
 end
 
 def rewrite_events(raw, avatar_start)

--- a/source/client/code/http_json_hash/unpacker.rb
+++ b/source/client/code/http_json_hash/unpacker.rb
@@ -26,12 +26,21 @@ module HttpJsonHash
 
     def unpacked(body, path, args)
       json = JSON.parse!(body)
-      service_error(path, args, body, 'body is not JSON Hash') unless json.instance_of?(Hash)
-      service_error(path, args, body, 'body has embedded exception') if json.key?('exception')
-      service_error(path, args, body, 'body is missing :path key') unless json.key?(path)
+      error = hash_error(json, path)
+      service_error(path, args, body, error) if error
       json[path]
     rescue JSON::ParserError
       service_error(path, args, body, 'body is not JSON')
+    end
+
+    # The message describing the first problem with the parsed body, or nil if
+    # it is a Hash carrying the requested path's key and no embedded exception.
+    def hash_error(json, path)
+      return 'body is not JSON Hash' unless json.instance_of?(Hash)
+      return 'body has embedded exception' if json.key?('exception')
+      return 'body is missing :path key' unless json.key?(path)
+
+      nil
     end
 
     # - - - - - - - - - - - - - - - - - - - - -

--- a/source/server/app/app.rb
+++ b/source/server/app/app.rb
@@ -47,7 +47,8 @@ module DashboardApp
           id = params[:id]
           was_index = params[:was_index].to_i
           now_index = params[:now_index].to_i
-          json({ diff_summary: externals.saver.diff_summary(id, was_index, now_index) })
+          summary = externals.saver.diff_summary(id, was_index, now_index)
+          json({ diff_summary: summary })
         end
       end
     end
@@ -101,9 +102,10 @@ module DashboardApp
 
     # Resolves the shared id in @id (a kata, group or cluster id) up to the
     # topmost entity and decides how the page renders it:
-    # - @cluster_id is the cluster the id belongs to (nil for a standalone group);
-    #   it is the id the URL is canonicalised onto.
-    # - @group_id is the child group whose avatars are shown first (cd.groupId()).
+    # - @cluster_id is the cluster the id belongs to (nil for a standalone
+    #   group); it is the id the URL is canonicalised onto.
+    # - @group_id is the child group whose avatars are shown first
+    #   (cd.groupId()).
     # - @tabs is one entry per child group of a cluster (id + LTF display_name);
     #   it is empty for a standalone group, so today's single view is unchanged.
     # A cluster shows one tab per child group (duplicate-LTF children each get
@@ -127,18 +129,18 @@ module DashboardApp
       end
     rescue StandardError
       # Resolving is best-effort: if the id resolves to nothing (or the saver is
-      # unreachable), render as a standalone group keyed on the given id, and let
-      # the per-child fetches surface any error.
+      # unreachable), render as a standalone group keyed on the given id, and
+      # let the per-child fetches surface any error.
       @cluster_id = nil
       @tabs = []
       @group_id = @id
     end
 
-    # The canonical URL of the cluster the requested id sits in: the cluster's own
-    # /show URL, carrying the resolved child group as ?group_id= so the same tab
-    # stays active, and keeping every other query param (eg sort_by). Browsers
-    # reach this app through nginx, which strips the /dashboard prefix, so the
-    # prefix is put back here - as layout.erb does for the asset paths.
+    # The canonical URL of the cluster the requested id sits in: the cluster's
+    # own /show URL, carrying the resolved child group as ?group_id= so the same
+    # tab stays active, and keeping every other query param (eg sort_by).
+    # Browsers reach this app through nginx, which strips the /dashboard prefix,
+    # so the prefix is put back here - as layout.erb does for the asset paths.
     def cluster_url
       query = request.params.merge('group_id' => @group_id)
       "/dashboard/show/#{@cluster_id}?#{Rack::Utils.build_query(query)}"
@@ -195,7 +197,9 @@ module DashboardApp
         colour: light.colour,
         time: light.time_a
       }
-      element['predicted'] = light.predicted if light.predicted && light.predicted != 'none'
+      if light.predicted && light.predicted != 'none'
+        element['predicted'] = light.predicted
+      end
       element['revert'] = light.revert if light.revert
       element['checkout'] = light.checkout if light.checkout
       element['filename'] = light.filename if light.filename

--- a/source/server/app/app_base.rb
+++ b/source/server/app/app_base.rb
@@ -9,16 +9,16 @@ require 'digest'
 module DashboardApp
   class AppBase < Sinatra::Base
     # Compiled assets live in ${APP_DIR}/assets, a sibling of source/, populated
-    # by the Dockerfile from the asset_builder stage, which keeps the precompiled
-    # app.css/app.js out of the repo tree.
+    # by the Dockerfile from the asset_builder stage, which keeps the
+    # precompiled app.css/app.js out of the repo tree.
     ASSETS_DIR = "#{ENV.fetch('APP_DIR')}/assets".freeze
 
-    # Returns the public URL path for a compiled asset, fingerprinted with a short
-    # hash of its content, eg "/assets/app-1a2b3c4d.css". Embedding the hash in the
-    # path gives each version a unique URL, so it can be cached immutably for a
-    # year; browsers then serve it from cache instead of re-pulling it on every
-    # page navigation through nginx's rate-limited /dashboard/ zone (which
-    # previously tripped a 429).
+    # Returns the public URL path for a compiled asset, fingerprinted with a
+    # short hash of its content, eg "/assets/app-1a2b3c4d.css". Embedding the
+    # hash in the path gives each version a unique URL, so it can be cached
+    # immutably for a year; browsers then serve it from cache instead of
+    # re-pulling it on every page navigation through nginx's rate-limited
+    # /dashboard/ zone (which previously tripped a 429).
     def self.asset_path(filename)
       src  = "#{ASSETS_DIR}/#{filename}"
       hash = Digest::SHA256.file(src).hexdigest[0, 8]
@@ -39,22 +39,24 @@ module DashboardApp
     silently { register Sinatra::Contrib }
     set :port, ENV.fetch('PORT', nil)
 
-    # Encode json() responses with the stdlib JSON module. Sinatra::Contrib's own
-    # default encoder is the legacy MultiJson constant, and its encoder lookup
-    # prefers :encode over :generate - multi_json warns about both, putting two
-    # deprecation lines on stderr. ::JSON responds only to :generate, so the
-    # encoded output is unchanged and nothing is written to stderr.
+    # Encode json() responses with the stdlib JSON module. Sinatra::Contrib's
+    # own default encoder is the legacy MultiJson constant, and its encoder
+    # lookup prefers :encode over :generate - multi_json warns about both,
+    # putting two deprecation lines on stderr. ::JSON responds only to
+    # :generate, so the encoded output is unchanged and nothing is written to
+    # stderr.
     set :json_encoder, ::JSON
 
     # Send redirects as a path, not a full URL. nginx fronts this app and
     # terminates TLS, so the scheme and host Sinatra sees are its own (http, the
-    # container) not the ones the browser used; a path Location leaves the browser
-    # to keep its own scheme and host.
+    # container) not the ones the browser used; a path Location leaves the
+    # browser to keep its own scheme and host.
     set :absolute_redirects, false
 
     # Permit all Host headers; nginx fronts this app and validates Host. Without
-    # this, Sinatra's development-mode host authorization rejects any Host that is
-    # not localhost/.test (eg Rack::Test's example.org) with 'Host not permitted'.
+    # this, Sinatra's development-mode host authorization rejects any Host that
+    # is not localhost/.test (eg Rack::Test's example.org) with 'Host not
+    # permitted'.
     set :host_authorization, {}
 
     # - - - - - - - - - - - - - - - -

--- a/source/server/app/external_saver.rb
+++ b/source/server/app/external_saver.rb
@@ -39,7 +39,8 @@ module DashboardApp
     end
 
     def diff_summary(id, was_index, now_index)
-      @http.get(__method__, { id: id, was_index: was_index, now_index: now_index })
+      @http.get(__method__,
+                { id: id, was_index: was_index, now_index: now_index })
     end
   end
 end

--- a/source/server/app/helpers/td_gapper.rb
+++ b/source/server/app/helpers/td_gapper.rb
@@ -140,7 +140,9 @@ module DashboardApp
 
       empty_column = ->(td) { gapped.all? { |_, h| h[td] == [] } }
       collapsed_column = ->(td) { gapped.all? { |_, h| h[td].is_a?(Hash) } }
-      lightless_column = ->(td) { empty_column.call(td) || collapsed_column.call(td) }
+      lightless_column = lambda do |td|
+        empty_column.call(td) || collapsed_column.call(td)
+      end
       delete_column = ->(td) { gapped.each_value { |h| h.delete(td) } }
 
       kata_id = gapped.keys[0]

--- a/source/server/app/http_json_hash/unpacker.rb
+++ b/source/server/app/http_json_hash/unpacker.rb
@@ -25,12 +25,22 @@ module DashboardApp
 
       def unpacked(body, path, args)
         json = JSON.parse!(body)
-        service_error(path, args, body, 'body is not JSON Hash') unless json.instance_of?(Hash)
-        service_error(path, args, body, 'body has embedded exception') if json.key?('exception')
-        service_error(path, args, body, 'body is missing :path key') unless json.key?(path)
+        error = hash_error(json, path)
+        service_error(path, args, body, error) if error
         json[path]
       rescue JSON::ParserError
         service_error(path, args, body, 'body is not JSON')
+      end
+
+      # The message describing the first problem with the parsed body, or nil if
+      # it is a Hash carrying the requested path's key and no embedded
+      # exception.
+      def hash_error(json, path)
+        return 'body is not JSON Hash' unless json.instance_of?(Hash)
+        return 'body has embedded exception' if json.key?('exception')
+        return 'body is missing :path key' unless json.key?(path)
+
+        nil
       end
 
       def service_error(path, args, body, message)

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -24,21 +24,21 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=',  48 ],
+    [ 'test.count',    stats['test_count'],    '>=',  49 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '==',  0 ],
     [ 'test.errors',   stats['error_count'  ], '==',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '==',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 608 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 626 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '==',   0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '==',   0 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '==',   0 ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 448 ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 455 ],
     [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '==',   0 ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=',  64 ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=',  66 ],
     [ 'code.branches.missed',  code_cov['branches']['missed'], '==',   0 ],
   ]
 end

--- a/test/server/diff_summary_test.rb
+++ b/test/server/diff_summary_test.rb
@@ -1,0 +1,32 @@
+require_relative 'test_base'
+require_relative 'saver_data_builder'
+require 'json'
+
+class DiffSummaryTest < TestBase
+  include SaverDataBuilder
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'd1f5s1', %w(
+  | GET /diff_summary returns one entry per file, naming it and counting its
+  | added, deleted and unchanged lines between the two given event indexes
+  ) do
+    group_id = create_group('Bash, bats')
+    kata_id = join_avatar(group_id)
+    edit_a_file(kata_id)
+
+    get "/diff_summary?id=#{kata_id}&was_index=0&now_index=1",
+        {}, { 'HTTP_ACCEPT' => 'application/json' }
+    assert status?(200), "status=#{status}"
+
+    diffs = JSON.parse(last_response.body)['diff_summary']
+    by_name = diffs.to_h { |diff| [diff['new_filename'], diff] }
+    assert_equal %w[cyber-dojo.sh hiker.sh], by_name.keys.sort, diffs
+
+    hiker = by_name['hiker.sh']
+    assert_equal 'changed', hiker['type'], hiker
+    assert_equal({ 'added' => 2, 'deleted' => 0, 'same' => 1 },
+                 hiker['line_counts'], hiker)
+    assert_equal 'unchanged', by_name['cyber-dojo.sh']['type'], by_name
+  end
+end


### PR DESCRIPTION
  Long lines here come from long identifiers and embedded fixture data rather
  than dense logic, so rubocop's 120-char default bought nothing but room to
  sprawl. Creator settled on 80 (cyber-dojo/creator#46); this brings dashboard
  alongside it. Web is still on the default.

  Layout/LineLength Max drops to 80, which also engages Style/IfUnlessModifier:
  that cop wants the one-line modifier form whenever it fits inside Max, so
  lowering the ceiling is what pushes a long "do_something(...) if condition"
  out into an if/end block.

  21 lines in source/ and 17 in bin/ were over. The reshaping:

  - Both unpackers grow a hash_error method. Expanding their three modifier guards would have pushed unpacked past Metrics/MethodLength, so the message choice moves out instead, returning the first problem or nil. Same messages, same order, same raise-on-first-problem behaviour - and the server, client and creator unpackers now agree, which is one less way for them to drift.
  - The four colour tables in bin/create_cluster_kata.rb and bin/create_group_kata.rb are laid out one entry per line. That keeps the shell error message and expected stdout blocks intact and readable, where wrapping them mid-string would not have been.
  - RED_STDOUT splits at an existing \n boundary, using the adjacent-literal idiom the file already uses. The string is byte-identical.
  - app.rb's predicted assignment becomes an if/end; its diff_summary call gets a local; td_gapper's lightless_column lambda becomes a do/end.
  - Nine comment paragraphs rewrapped.

  Two things the cap flushed out, neither about line length:

  - /diff_summary had no happy-path test. Splitting an 88-char line into two exposed it: the only test requesting that route stubs the saver to fail, so the json() half never ran, and on one line that counted as covered. diff_summary_test.rb now drives it for real, asserting one entry per file with its type and line counts. Line coverage is back to 100%.
  - create_group_kata.rb posted the same kata_file_edit twice, hidden inside two 117-char lines. Breaking them made the duplication visible; it is now one append_comment helper, which also brought extra_file_edits back under Metrics/MethodLength.

  check_test_metrics.rb pins move up for the code the extractions added:
  test.count 48 to 49, test.lines.total 608 to 626, code.lines.total 448 to 455,
  code.branches.total 64 to 66. Both missed counts stay pinned at == 0, which is
  the pair that matters.

  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>