### PR TITLE
Serve /dashboard/... in the app, not just after nginx strips it

### DIFF
--- a/source/server/config/config.ru
+++ b/source/server/config/config.ru
@@ -11,4 +11,11 @@ end
 require_relative '../dashboard/app'
 require_relative '../dashboard/externals'
 externals = DashboardApp::Externals.new
-run DashboardApp::App.new(externals)
+app = DashboardApp::App.new(externals)
+
+# Mounted at both prefixes for the cutover. nginx currently rewrites
+# /dashboard/... down to /..., which the / mount serves exactly as before;
+# once that rewrite goes, the intact path arrives and the /dashboard mount
+# serves it. The / mount is deleted last, so nginx and the app never have to
+# be released together.
+run Rack::URLMap.new('/' => app, '/dashboard' => app)

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -24,14 +24,14 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=',  49 ],
+    [ 'test.count',    stats['test_count'],    '>=',  50 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '==',  0 ],
     [ 'test.errors',   stats['error_count'  ], '==',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '==',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 626 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 639 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '==',   0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '==',   0 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '==',   0 ],

--- a/test/server/config_ru_mounts_both_prefixes_test.rb
+++ b/test/server/config_ru_mounts_both_prefixes_test.rb
@@ -1,0 +1,27 @@
+require_relative 'test_base'
+require 'json'
+require 'rack/builder'
+
+class ConfigRuMountsBothPrefixesTest < TestBase
+  # The suite normally drives App directly. This test needs the rack app that
+  # config.ru actually builds, since the two mount points live only there.
+  def app
+    @app ||= Rack::Builder.parse_file(
+      File.expand_path('../../source/config/config.ru', __dir__)
+    )
+  end
+
+  test 'cnfg21', %w(
+  | config.ru serves /alive at both of its mount points: the bare path, which
+  | is what nginx's rewrite produces today, and the /dashboard path, which
+  | arrives intact once that rewrite is deleted.
+  ) do
+    get '/alive'
+    assert_equal 200, last_response.status, last_response.body
+    assert_equal({ 'alive?' => true }, JSON.parse(last_response.body))
+
+    get '/dashboard/alive'
+    assert_equal 200, last_response.status, last_response.body
+    assert_equal({ 'alive?' => true }, JSON.parse(last_response.body))
+  end
+end


### PR DESCRIPTION
  nginx rewrites /dashboard/... down to /... before proxying, so the app has
  never seen its own prefix, which is why six places hardcode /dashboard in
  redirects, asset links and fetch calls.

  config.ru now mounts the app at both / and /dashboard. Nothing changes in
  production yet: the rewrite still lands requests on the / mount. Deleting the
  rewrite makes the /dashboard mount serve them, and the / mount goes last, so
  nginx and the app never have to be released together.

  The new test is the only one that loads config.ru - the rest of the suite
  drives App directly, so nothing else would notice a mount going missing.