### PR TITLE
Serve dashboard only under its own prefix

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,13 +1,19 @@
 sonar.projectKey=cyber-dojo_dashboard
 sonar.organization=cyber-dojo
 
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2,e3
+
 sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S6470
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/Dockerfile
 
-sonar.issue.ignore.multicriteria=e2
 sonar.issue.ignore.multicriteria.e2.ruleKey=Web:S5256
 sonar.issue.ignore.multicriteria.e2.resourceKey=source/server/dashboard/views/traffic_lights.erb
+
+# Clear-text protocol. The healthcheck requests http://0.0.0.0 inside the
+# container's own network namespace, where puma serves plain HTTP by design;
+# TLS terminates at nginx, well before this.
+sonar.issue.ignore.multicriteria.e3.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e3.resourceKey=source/server/config/healthcheck.sh
 
 sonar.coverage.exclusions=**/**
 sonar.tests=test/

--- a/source/server/config/config.ru
+++ b/source/server/config/config.ru
@@ -13,9 +13,6 @@ require_relative '../dashboard/externals'
 externals = DashboardApp::Externals.new
 app = DashboardApp::App.new(externals)
 
-# Mounted at both prefixes for the cutover. nginx currently rewrites
-# /dashboard/... down to /..., which the / mount serves exactly as before;
-# once that rewrite goes, the intact path arrives and the /dashboard mount
-# serves it. The / mount is deleted last, so nginx and the app never have to
-# be released together.
-run Rack::URLMap.new('/' => app, '/dashboard' => app)
+# The app owns its prefix: nginx passes /dashboard/... through untouched, so
+# there is one mount, and SCRIPT_NAME tells the app where it is mounted.
+run Rack::URLMap.new('/dashboard' => app)

--- a/source/server/config/healthcheck.sh
+++ b/source/server/config/healthcheck.sh
@@ -14,7 +14,8 @@ set -Eeu
 readonly PORT="${CYBER_DOJO_DASHBOARD_PORT}"
 readonly READY_LOG_FILENAME=/tmp/ready.log
 
-wget http://0.0.0.0:${PORT}/ready -q -O - >> "${READY_LOG_FILENAME}" 2>&1
+# /dashboard is the app's only mount, so the probe carries the prefix too.
+wget http://0.0.0.0:${PORT}/dashboard/ready -q -O - >> "${READY_LOG_FILENAME}" 2>&1
 echo >> "${READY_LOG_FILENAME}"  # add a newline
 
 # keep only most recent 500 lines

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -31,7 +31,7 @@ def table_data
     [ 'test.errors',   stats['error_count'  ], '==',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '==',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 639 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 638 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '==',   0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '==',   0 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '==',   0 ],

--- a/test/server/config_ru_mounts_dashboard_prefix_only_test.rb
+++ b/test/server/config_ru_mounts_dashboard_prefix_only_test.rb
@@ -2,7 +2,7 @@ require_relative 'test_base'
 require 'json'
 require 'rack/builder'
 
-class ConfigRuMountsBothPrefixesTest < TestBase
+class ConfigRuMountsDashboardPrefixOnlyTest < TestBase
   # The suite normally drives App directly. This test needs the rack app that
   # config.ru actually builds, since the two mount points live only there.
   def app
@@ -12,16 +12,15 @@ class ConfigRuMountsBothPrefixesTest < TestBase
   end
 
   test 'cnfg21', %w(
-  | config.ru serves /alive at both of its mount points: the bare path, which
-  | is what nginx's rewrite produces today, and the /dashboard path, which
-  | arrives intact once that rewrite is deleted.
+  | config.ru serves /alive under its /dashboard mount only. The bare path is
+  | not served: nginx passes the prefix through rather than stripping it, so
+  | nothing asks for /alive any more.
   ) do
-    get '/alive'
-    assert_equal 200, last_response.status, last_response.body
-    assert_equal({ 'alive?' => true }, JSON.parse(last_response.body))
-
     get '/dashboard/alive'
     assert_equal 200, last_response.status, last_response.body
     assert_equal({ 'alive?' => true }, JSON.parse(last_response.body))
+
+    get '/alive'
+    assert_equal 404, last_response.status, last_response.body
   end
 end


### PR DESCRIPTION
  nginx now passes /dashboard/... through untouched in every environment, so
  the / mount has nothing left to serve. Removing it makes SCRIPT_NAME
  unambiguous: the app is mounted in exactly one place and can build its own
  URLs from it, instead of spelling /dashboard into redirects and asset links.

  The container healthcheck was the one thing still asking for a bare path, so
  it now requests /dashboard/ready. Nothing else probes by URL: no ALB or ECS
  health-check path, and no other repo.

  The mount test inverts with the mount, and its name follows: the bare path is
  now expected to 404.