### PR TITLE
Reach the mount point through helpers, not interpolation

### DIFF
--- a/source/server/dashboard/assets/javascripts/hover_tips.js
+++ b/source/server/dashboard/assets/javascripts/hover_tips.js
@@ -14,7 +14,7 @@
     setTip($light, () => {
       const args = { id:kataId, was_index:light.previous_index, now_index:light.index };
       const params = new URLSearchParams(args);
-      fetch(`${cd.mountPath}/diff_summary?${params}`, { headers: cd.lib.jsonHeaders })
+      fetch(cd.mountedPath(`/diff_summary?${params}`), { headers: cd.lib.jsonHeaders })
         .then(r => r.json())
         .then(json => {
           const diffSummary = json.diff_summary;

--- a/source/server/dashboard/assets/javascripts/lib.js
+++ b/source/server/dashboard/assets/javascripts/lib.js
@@ -10,6 +10,10 @@
     'X-Requested-With': 'XMLHttpRequest'
   };
 
+  // The URL for a route under wherever this app is mounted. Mirrors path_to()
+  // in ruby; cd.mountPath is set by layout.erb from SCRIPT_NAME.
+  cd.mountedPath = (route) => `${cd.mountPath}${route}`;
+
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // Older katas did not distinguish between
   //   - an auto-revert, from an incorrect test prediction

--- a/source/server/dashboard/assets/javascripts/refresh.js
+++ b/source/server/dashboard/assets/javascripts/refresh.js
@@ -31,7 +31,7 @@ $(() => {
       detailed:detailed
     };
     const params = new URLSearchParams(args);
-    fetch(`${cd.mountPath}/heartbeat/${cd.groupId()}?${params}`, { headers: cd.lib.jsonHeaders })
+    fetch(cd.mountedPath(`/heartbeat/${cd.groupId()}?${params}`), { headers: cd.lib.jsonHeaders })
       .then(r => r.json())
       .then(data => {
         refreshTableHeadWith(data.time_ticks);

--- a/source/server/dashboard/views/progress_button.erb
+++ b/source/server/dashboard/views/progress_button.erb
@@ -29,7 +29,7 @@ $(() => {
   });
 
   const openProgressDialog = () => {
-    fetch(`${cd.mountPath}/progress/${cd.groupId()}`, { headers: cd.lib.jsonHeaders })
+    fetch(cd.mountedPath(`/progress/${cd.groupId()}`), { headers: cd.lib.jsonHeaders })
       .then(r => r.json())
       .then(data => {
         dialog.querySelector('.dialog-body').innerHTML = progressTable(data.katas);

--- a/source/server/dashboard/views/show.erb
+++ b/source/server/dashboard/views/show.erb
@@ -45,7 +45,7 @@ $(() => {
   // Advance the rotation onto the next active group; if that is the current
   // group (nothing else active) just refresh in place.
   const rotateToNextActiveGroup = () => {
-    fetch(`${cd.mountPath}/active_groups/${cd.id()}`, { headers: cd.lib.jsonHeaders })
+    fetch(cd.mountedPath(`/active_groups/${cd.id()}`), { headers: cd.lib.jsonHeaders })
       .then((response) => response.json())
       .then((active) => {
         const nextId = nextActiveGroupId(active);

--- a/test/server/active_groups_test.rb
+++ b/test/server/active_groups_test.rb
@@ -72,7 +72,7 @@ class ActiveGroupsTest < TestBase
 
   # GETs /active_groups/<id> as json, asserts 200, and returns the parsed body.
   def get_active_groups(id)
-    get "#{App::MOUNT_PATH}/active_groups/#{id}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    get mounted_path("active_groups/#{id}"), {}, { 'HTTP_ACCEPT' => 'application/json' }
     assert status?(200), "status=#{status}"
     JSON.parse(last_response.body)
   end

--- a/test/server/assets_test.rb
+++ b/test/server/assets_test.rb
@@ -9,7 +9,7 @@ class AssetsTest < TestBase
     |immutable Cache-Control header, so browsers do not re-pull it
     |through nginx's rate-limited /dashboard/ zone on every navigation
   ] do
-    get "#{App::MOUNT_PATH}#{App::CSS_PATH}"
+    get mounted_asset_path(App::CSS_PATH)
     assert status?(200), status
     assert css_content?, content_type
     cache_control = last_response.headers['Cache-Control']
@@ -23,7 +23,7 @@ class AssetsTest < TestBase
     |the fingerprinted JS path is served as javascript with the
     |same one-year immutable Cache-Control header, as for kf1
   ] do
-    get "#{App::MOUNT_PATH}#{App::JS_PATH}"
+    get mounted_asset_path(App::JS_PATH)
     assert status?(200), status
     assert js_content?, content_type
     cache_control = last_response.headers['Cache-Control']
@@ -48,10 +48,10 @@ class AssetsTest < TestBase
     |the layout links each asset by its fingerprinted path, under the mount
     |point. The app writes no prefix itself: path_to() prepends SCRIPT_NAME.
   ] do
-    get "#{App::MOUNT_PATH}/show/aB3kf4", {}, { 'HTTP_ACCEPT' => 'text/html' }
+    get mounted_path('show/aB3kf4'), {}, { 'HTTP_ACCEPT' => 'text/html' }
     assert status?(200), status
     html = last_response.body
-    assert html.include?(%Q{href="#{App::MOUNT_PATH}#{App::CSS_PATH}"}), html
-    assert html.include?(%Q{src="#{App::MOUNT_PATH}#{App::JS_PATH}"}), html
+    assert html.include?(%Q{href="#{mounted_asset_path(App::CSS_PATH)}"}), html
+    assert html.include?(%Q{src="#{mounted_asset_path(App::JS_PATH)}"}), html
   end
 end

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -31,7 +31,7 @@ def table_data
     [ 'test.errors',   stats['error_count'  ], '==',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '==',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 640 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 644 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '==',   0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '==',   0 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '==',   0 ],

--- a/test/server/cluster_tabs_test.rb
+++ b/test/server/cluster_tabs_test.rb
@@ -29,9 +29,9 @@ class ClusterTabsTest < TestBase
   | a child-group id inside a cluster redirects to the cluster's own URL,
   | carrying that child as group_id so it stays the active tab
   ) do
-    get "#{App::MOUNT_PATH}/show/9bYWLV", {}, { 'HTTP_ACCEPT' => 'text/html' }
+    get mounted_path('show/9bYWLV'), {}, { 'HTTP_ACCEPT' => 'text/html' }
     assert status?(302), "status=#{status}"
-    expected = "#{App::MOUNT_PATH}/show/#{CLUSTER_ID}?group_id=9bYWLV"
+    expected = mounted_path("show/#{CLUSTER_ID}?group_id=9bYWLV")
     assert_equal expected, redirect_location
   end
 
@@ -64,9 +64,9 @@ class ClusterTabsTest < TestBase
   | the redirect to the cluster URL keeps the other query params, so eg a
   | chosen sort survives the hop
   ) do
-    get "#{App::MOUNT_PATH}/show/9bYWLV", { sort_by: 'lights' }, { 'HTTP_ACCEPT' => 'text/html' }
+    get mounted_path('show/9bYWLV'), { sort_by: 'lights' }, { 'HTTP_ACCEPT' => 'text/html' }
     assert status?(302), "status=#{status}"
-    expected = "#{App::MOUNT_PATH}/show/#{CLUSTER_ID}?sort_by=lights&group_id=9bYWLV"
+    expected = mounted_path("show/#{CLUSTER_ID}?sort_by=lights&group_id=9bYWLV")
     assert_equal expected, redirect_location
   end
 
@@ -101,7 +101,7 @@ class ClusterTabsTest < TestBase
 
   # GETs /show/<id> as html, asserts a 200, and returns the response body.
   def show_html(id, params = {})
-    get "#{App::MOUNT_PATH}/show/#{id}", params, { 'HTTP_ACCEPT' => 'text/html' }
+    get mounted_path("show/#{id}"), params, { 'HTTP_ACCEPT' => 'text/html' }
     assert status?(200), "status=#{status}"
     last_response.body
   end

--- a/test/server/diff_summary_test.rb
+++ b/test/server/diff_summary_test.rb
@@ -15,7 +15,7 @@ class DiffSummaryTest < TestBase
     kata_id = join_avatar(group_id)
     edit_a_file(kata_id)
 
-    get "#{App::MOUNT_PATH}/diff_summary?id=#{kata_id}&was_index=0&now_index=1",
+    get mounted_path("diff_summary?id=#{kata_id}&was_index=0&now_index=1"),
         {}, { 'HTTP_ACCEPT' => 'application/json' }
     assert status?(200), "status=#{status}"
 

--- a/test/server/error_handler_test.rb
+++ b/test/server/error_handler_test.rb
@@ -19,7 +19,7 @@ class ErrorHandlerTest < TestBase
 
     exception = assert_500_diagnostic['exception']
     assert_equal %w[backtrace http_service request], exception.keys.sort, exception
-    assert_equal({ 'path' => "#{App::MOUNT_PATH}/diff_summary", 'body' => nil },
+    assert_equal({ 'path' => mounted_path('diff_summary'), 'body' => nil },
                  exception['request'], exception)
 
     service = exception['http_service']
@@ -99,7 +99,7 @@ class ErrorHandlerTest < TestBase
     request_body = 'some-request-body'
 
     exception = assert_500_diagnostic(JSON_HEADERS.merge(input: request_body))['exception']
-    assert_equal({ 'path' => "#{App::MOUNT_PATH}/diff_summary", 'body' => request_body },
+    assert_equal({ 'path' => mounted_path('diff_summary'), 'body' => request_body },
                  exception['request'], exception)
   end
 
@@ -111,7 +111,7 @@ class ErrorHandlerTest < TestBase
 
   def assert_500_diagnostic(env = JSON_HEADERS)
     stdout, stderr = capture_io do
-      get "#{App::MOUNT_PATH}/diff_summary?id=#{GROUP_ID}&was_index=1&now_index=2", {}, env
+      get mounted_path("diff_summary?id=#{GROUP_ID}&was_index=1&now_index=2"), {}, env
     end
     assert status?(500), "status=#{status}"
     assert_equal 'application/json', content_type, content_type

--- a/test/server/heartbeat_test.rb
+++ b/test/server/heartbeat_test.rb
@@ -147,7 +147,7 @@ class HeartbeatTest < TestBase
 
   # GETs /heartbeat/<id> as json, asserts 200, and returns the parsed body.
   def get_heartbeat(id, query = '')
-    get "#{App::MOUNT_PATH}/heartbeat/#{id}?#{query}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    get mounted_path("heartbeat/#{id}?#{query}"), {}, { 'HTTP_ACCEPT' => 'application/json' }
     assert status?(200), "status=#{status}"
     JSON.parse(last_response.body)
   end

--- a/test/server/probes_test.rb
+++ b/test/server/probes_test.rb
@@ -84,7 +84,7 @@ class ProbesTest < TestBase
   # the parsed body.
   def assert_probe_200(path, &block)
     stdout, stderr = capture_io do
-      get "#{App::MOUNT_PATH}/#{path}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+      get mounted_path(path), {}, { 'HTTP_ACCEPT' => 'application/json' }
     end
     assert status?(200), "status=#{status}"
     assert_equal '', stderr, :stderr

--- a/test/server/progress_test.rb
+++ b/test/server/progress_test.rb
@@ -21,7 +21,7 @@ class ProgressTest < TestBase
     index_of = saver_get('group_joined', { id: group_id })
                .to_h { |index, o| [o['id'], index.to_i] }
 
-    get "#{App::MOUNT_PATH}/progress/#{group_id}", {}, { 'HTTP_ACCEPT' => 'application/json' }
+    get mounted_path("progress/#{group_id}"), {}, { 'HTTP_ACCEPT' => 'application/json' }
     assert status?(200), "status=#{status}"
 
     expected = [

--- a/test/server/test_base.rb
+++ b/test/server/test_base.rb
@@ -21,6 +21,19 @@ class TestBase < Id58TestBase
     @externals ||= Externals.new
   end
 
+  # The URL a browser uses for a route: the app's mount point plus the route.
+  # Takes a bare route name, eg 'show/vntRcc'. It does not strip a leading
+  # slash: accepting both forms hides a doubled-slash path.
+  def mounted_path(route)
+    "#{App::MOUNT_PATH}/#{route}"
+  end
+
+  # The same, for a path that already starts with a slash, eg the
+  # fingerprinted asset paths in App::CSS_PATH and App::JS_PATH.
+  def mounted_asset_path(path)
+    "#{App::MOUNT_PATH}#{path}"
+  end
+
   # True when the last response status matches expected.
   def status?(expected)
     status == expected


### PR DESCRIPTION
  MOUNT_PATH was spelled into 18 test sites and cd.mountPath into 4 JavaScript
  ones, so every place that wanted a URL restated how one is built.

  The test base now offers mounted_path('show/vntRcc') for a route and
  mounted_asset_path(App::CSS_PATH) for a path that already starts with a slash;
  lib.js offers cd.mountedPath(route). MOUNT_PATH is left in the two helpers and
  app.rb, and nowhere else.

  Two helpers rather than one because the inputs differ: mounted_path takes a
  bare route name and deliberately does not strip a leading slash, since
  accepting both forms hides a doubled-slash path.

  This follows creator, which arrived at the same shape while dropping its own /
  mount. Keeping them identical is worth a little churn here: the two test bases
  sit side by side after the merge.