### PR TITLE
Delete build_image.sh's copy of exit_non_zero

### DIFF
--- a/bin/build_image.sh
+++ b/bin/build_image.sh
@@ -21,11 +21,6 @@ show_help()
 EOF
 }
 
-exit_non_zero()
-{
-  kill -INT $$
-}
-
 check_args()
 {
   case "${1:-}" in


### PR DESCRIPTION
  It shadowed the one in lib.sh, so the fix that made failures actually exit did
  not reach this script: sourcing lib.sh at line 5 installs the INT trap, then
  line 24 redefined exit_non_zero as kill -INT $$, and the trap swallowed the
  signal. A bad argument printed its error and carried on into the build.

  Shell warns about none of this - whichever definition comes last silently wins,
  so grepping for exit_non_zero() rather than its callers is the only way to see
  a second one exists.