### PR TITLE
Attach the rubocop config to its attestation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
           kosli attest junit
             --name=dashboard.rubocop-lint
             --results-dir=./reports/rubocop
+            --attachments=./.rubocop.yml
 
 
   sonarcloud-scan:


### PR DESCRIPTION
  The junit results say tests='35' failures='0', which means nothing without
  knowing which cops ran: the same output would come from a config enabling one
  cop as from a thorough one. The config is what makes the result readable, so it
  travels with it.