### PR TITLE
Run the linter as the invoking user

### DIFF
--- a/bin/rubocop_lint.sh
+++ b/bin/rubocop_lint.sh
@@ -5,8 +5,13 @@ export ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 rm -rf "${ROOT_DIR}/reports/rubocop" &> /dev/null || true
 mkdir -p "${ROOT_DIR}/reports/rubocop"
 
+# As the invoking user, so junit.xml belongs to whoever ran this rather than to
+# the container's user. A file owned by someone else breaks kosli attest, which
+# copies evidence with PreserveOwner and cannot chown to another uid, and is
+# unwelcome in a working tree regardless.
 docker run \
   --rm \
+  --user "$(id -u):$(id -g)" \
   --volume "${ROOT_DIR}/reports/rubocop/:/reports/" \
   --volume "${ROOT_DIR}:/app" \
   cyberdojo/rubocop \


### PR DESCRIPTION
  The rubocop container wrote reports/rubocop/junit.xml as its own user, so on a
  linux runner the file belongs to someone else. That breaks the attestation as
  soon as it has more than one path to send: kosli attest copies evidence with
  PreserveOwner, and a non-root process cannot chown a file to another uid.

    chown /tmp/1800768837/reports/rubocop/junit.xml: operation not permitted

  Attaching .rubocop.yml in #431 is what supplied the second path. With one path
  the CLI tars in place and never copies, which is why this had been fine.

  Passing --user makes the container write as whoever ran it. Worth doing on its
  own account - a container should not leave files you cannot delete in your
  working tree - and it sidesteps the CLI's behaviour without waiting on it. That
  behaviour looks like a bug and is written up in
  ../kosli-cli-preserve-owner-bug.md for an issue against kosli-dev/cli.

  Docker Desktop maps ownership back to the calling user, so this is invisible on a
  mac and only shows on the runner.